### PR TITLE
BlueMark db200: add LED status and set ESP GPIO pins to enable CAN tr…

### DIFF
--- a/RemoteIDModule/RemoteIDModule.ino
+++ b/RemoteIDModule/RemoteIDModule.ino
@@ -74,6 +74,24 @@ void setup()
 #if AP_BLE_ENABLED
     ble.init();
 #endif
+
+#if defined(PIN_CAN_EN)
+    // optional CAN enable pin
+    pinMode(PIN_CAN_EN, OUTPUT);
+    digitalWrite(PIN_CAN_EN, HIGH);
+#endif
+
+#if defined(PIN_CAN_nSILENT)
+    // disable silent pin
+    pinMode(PIN_CAN_nSILENT, OUTPUT);
+    digitalWrite(PIN_CAN_nSILENT, HIGH);
+#endif
+
+#if defined(PIN_CAN_TERM)
+    // optional CAN termination control
+    pinMode(PIN_CAN_TERM, OUTPUT);
+    digitalWrite(PIN_CAN_TERM, HIGH);
+#endif
 }
 
 #define IMIN(x,y) ((x)<(y)?(x):(y))

--- a/RemoteIDModule/board_config.h
+++ b/RemoteIDModule/board_config.h
@@ -19,11 +19,20 @@
 #define PIN_UART_RX 2
 
 #elif defined(BOARD_BLUEMARK_DB200)
-#define PIN_CAN_TX GPIO_NUM_5
-#define PIN_CAN_RX GPIO_NUM_4
+
+#define PIN_CAN_TX GPIO_NUM_0 // this goes to the TX pin (= input) of the NXP CAN transceiver
+#define PIN_CAN_RX GPIO_NUM_5
+#define PIN_CAN_EN GPIO_NUM_4 // EN pin of the NXP CAN transceiver
+#define PIN_CAN_nSILENT GPIO_NUM_1 // CAN silent pin, active low
+
+// to enable termination resistors uncomment this line
+//#define PIN_CAN_TERM EN_NUM_10 // if set to ON, the termination resistors of the CAN bus are enabled
 
 #define PIN_UART_TX 3
 #define PIN_UART_RX 2
+
+#define PIN_STATUS_LED GPIO_NUM_8 // LED to signal the status
+#define STATUS_LED_ON 1
 
 #elif defined(BOARD_BLUEMARK_DB110)
 #define PIN_UART_TX 5

--- a/RemoteIDModule/mavlink.cpp
+++ b/RemoteIDModule/mavlink.cpp
@@ -3,6 +3,7 @@
  */
 #include <Arduino.h>
 #include "mavlink.h"
+#include "board_config.h"
 
 #define SERIAL_BAUD 115200
 
@@ -188,6 +189,13 @@ void MAVLinkSerial::arm_status_send(void)
         status = MAV_ODID_GOOD_TO_ARM;
     }
 
+#ifdef PIN_STATUS_LED
+        // LED off if good to arm
+        pinMode(PIN_STATUS_LED, OUTPUT);
+        digitalWrite(PIN_STATUS_LED, status==MAV_ODID_GOOD_TO_ARM?!STATUS_LED_ON:STATUS_LED_ON);
+#endif
+
+    
     mavlink_msg_open_drone_id_arm_status_send(
         chan,
         status,


### PR DESCRIPTION
added support for the new db200 MAVLink board

- add LED status control
- set GPIO pins of the ESP chip to enable the NXP transceiver chip