### PR TITLE
fix ble transmission protocols

### DIFF
--- a/RemoteIDModule/BLE_TX.cpp
+++ b/RemoteIDModule/BLE_TX.cpp
@@ -36,7 +36,7 @@ static esp_ble_gap_ext_adv_params_t legacy_adv_params = {
 
 static esp_ble_gap_ext_adv_params_t ext_adv_params_coded = {
     .type = ESP_BLE_GAP_SET_EXT_ADV_PROP_NONCONN_NONSCANNABLE_UNDIRECTED, //set to unicast advertising
-     .interval_min = 1200, //(unsigned int) 0.75*1000/(OUTPUT_RATE_HZ)/0.625; //allow ble controller to have some room for transmission.
+    .interval_min = 1200, //(unsigned int) 0.75*1000/(OUTPUT_RATE_HZ)/0.625; //allow ble controller to have some room for transmission.
     .interval_max = 1600, //(unsigned int) 1000/(OUTPUT_RATE_HZ)/0.625;
     .channel_map = ADV_CHNL_ALL,
     .own_addr_type = BLE_ADDR_TYPE_RANDOM,
@@ -152,103 +152,103 @@ bool BLE_TX::transmit_longrange(ODID_UAS_Data &UAS_data)
     return true;
 }
 
- bool BLE_TX::transmit_legacy(ODID_UAS_Data &UAS_data)
- {
-	static uint8_t legacy_phase = 0;
-	int legacy_length = 0;
-	// setup ASTM header
-	const uint8_t header[] { 0x1e, 0x16, 0xfa, 0xff, 0x0d }; //exclude the message counter
-	// combine header with payload
-	memset(legacy_payload, 0, sizeof(legacy_payload));
+bool BLE_TX::transmit_legacy(ODID_UAS_Data &UAS_data)
+{
+    static uint8_t legacy_phase = 0;
+    int legacy_length = 0;
+    // setup ASTM header
+    const uint8_t header[] { 0x1e, 0x16, 0xfa, 0xff, 0x0d }; //exclude the message counter
+    // combine header with payload
+    memset(legacy_payload, 0, sizeof(legacy_payload));
     memcpy(legacy_payload, header, sizeof(header));
 
-	switch (legacy_phase)
+    switch (legacy_phase)
     {
-		case  0:
-			ODID_Location_encoded location_encoded;
-			memset(&location_encoded, 0, sizeof(location_encoded));
-			if (encodeLocationMessage(&location_encoded, &UAS_data.Location) != ODID_SUCCESS) {
-				break;
-			}
+    case  0:
+        ODID_Location_encoded location_encoded;
+        memset(&location_encoded, 0, sizeof(location_encoded));
+        if (encodeLocationMessage(&location_encoded, &UAS_data.Location) != ODID_SUCCESS) {
+            break;
+        }
 
-            memcpy(&legacy_payload[sizeof(header)], &msg_counters[ODID_MSG_COUNTER_LOCATION], 1); //set packet counter
-            msg_counters[ODID_MSG_COUNTER_LOCATION]++;
-            //msg_counters[ODID_MSG_COUNTER_LOCATION] %= 256; //likely not be needed as it is defined as unint_8
+        memcpy(&legacy_payload[sizeof(header)], &msg_counters[ODID_MSG_COUNTER_LOCATION], 1); //set packet counter
+        msg_counters[ODID_MSG_COUNTER_LOCATION]++;
+        //msg_counters[ODID_MSG_COUNTER_LOCATION] %= 256; //likely not be needed as it is defined as unint_8
 
-			memcpy(&legacy_payload[sizeof(header) + 1], &location_encoded, sizeof(location_encoded));
-			legacy_length = sizeof(header) + 1 + sizeof(location_encoded);
+        memcpy(&legacy_payload[sizeof(header) + 1], &location_encoded, sizeof(location_encoded));
+        legacy_length = sizeof(header) + 1 + sizeof(location_encoded);
 
-			break;
+        break;
 
-		case  1:
-			ODID_BasicID_encoded basicid_encoded;
-			memset(&basicid_encoded, 0, sizeof(basicid_encoded));
-			if (encodeBasicIDMessage(&basicid_encoded, &UAS_data.BasicID[0]) != ODID_SUCCESS) {
-				break;
-			}
+    case  1:
+        ODID_BasicID_encoded basicid_encoded;
+        memset(&basicid_encoded, 0, sizeof(basicid_encoded));
+        if (encodeBasicIDMessage(&basicid_encoded, &UAS_data.BasicID[0]) != ODID_SUCCESS) {
+            break;
+        }
 
-            memcpy(&legacy_payload[sizeof(header)], &msg_counters[ODID_MSG_COUNTER_BASIC_ID], 1); //set packet counter
-            msg_counters[ODID_MSG_COUNTER_BASIC_ID]++;
-            //msg_counters[ODID_MSG_COUNTER_BASIC_ID] %= 256; //likely not be needed as it is defined as unint_8
+        memcpy(&legacy_payload[sizeof(header)], &msg_counters[ODID_MSG_COUNTER_BASIC_ID], 1); //set packet counter
+        msg_counters[ODID_MSG_COUNTER_BASIC_ID]++;
+        //msg_counters[ODID_MSG_COUNTER_BASIC_ID] %= 256; //likely not be needed as it is defined as unint_8
 
-			memcpy(&legacy_payload[sizeof(header) + 1], &basicid_encoded, sizeof(basicid_encoded));
-            legacy_length = sizeof(header) + 1 + sizeof(basicid_encoded);
+        memcpy(&legacy_payload[sizeof(header) + 1], &basicid_encoded, sizeof(basicid_encoded));
+        legacy_length = sizeof(header) + 1 + sizeof(basicid_encoded);
 
-			break;
+        break;
 
-		case  2:
-			ODID_SelfID_encoded selfid_encoded;
-			memset(&selfid_encoded, 0, sizeof(selfid_encoded));
-			if (encodeSelfIDMessage(&selfid_encoded, &UAS_data.SelfID) != ODID_SUCCESS) {
-				break;
-			}
+    case  2:
+        ODID_SelfID_encoded selfid_encoded;
+        memset(&selfid_encoded, 0, sizeof(selfid_encoded));
+        if (encodeSelfIDMessage(&selfid_encoded, &UAS_data.SelfID) != ODID_SUCCESS) {
+            break;
+        }
 
-            memcpy(&legacy_payload[sizeof(header)], &msg_counters[ODID_MSG_COUNTER_SELF_ID], 1); //set packet counter
-            msg_counters[ODID_MSG_COUNTER_SELF_ID]++;
-            //msg_counters[ODID_MSG_COUNTER_SELF_ID] %= 256; //likely not be needed as it is defined as uint_8
+        memcpy(&legacy_payload[sizeof(header)], &msg_counters[ODID_MSG_COUNTER_SELF_ID], 1); //set packet counter
+        msg_counters[ODID_MSG_COUNTER_SELF_ID]++;
+        //msg_counters[ODID_MSG_COUNTER_SELF_ID] %= 256; //likely not be needed as it is defined as uint_8
 
-			memcpy(&legacy_payload[sizeof(header) + 1], &selfid_encoded, sizeof(selfid_encoded));
-            legacy_length = sizeof(header) + 1 + sizeof(selfid_encoded);
+        memcpy(&legacy_payload[sizeof(header) + 1], &selfid_encoded, sizeof(selfid_encoded));
+        legacy_length = sizeof(header) + 1 + sizeof(selfid_encoded);
 
-			break;
+        break;
 
-		case  3:
-			ODID_System_encoded system_encoded;
-			memset(&system_encoded, 0, sizeof(system_encoded));
-			if (encodeSystemMessage(&system_encoded, &UAS_data.System) != ODID_SUCCESS) {
-				break;
-			}
+    case  3:
+        ODID_System_encoded system_encoded;
+        memset(&system_encoded, 0, sizeof(system_encoded));
+        if (encodeSystemMessage(&system_encoded, &UAS_data.System) != ODID_SUCCESS) {
+            break;
+        }
 
-            memcpy(&legacy_payload[sizeof(header)], &msg_counters[ODID_MSG_COUNTER_SYSTEM], 1); //set packet counter
-            msg_counters[ODID_MSG_COUNTER_SYSTEM]++;
-            //msg_counters[ODID_MSG_COUNTER_SYSTEM] %= 256; //likely not be needed as it is defined as uint_8
+        memcpy(&legacy_payload[sizeof(header)], &msg_counters[ODID_MSG_COUNTER_SYSTEM], 1); //set packet counter
+        msg_counters[ODID_MSG_COUNTER_SYSTEM]++;
+        //msg_counters[ODID_MSG_COUNTER_SYSTEM] %= 256; //likely not be needed as it is defined as uint_8
 
-			memcpy(&legacy_payload[sizeof(header) + 1], &system_encoded, sizeof(system_encoded));
-            legacy_length = sizeof(header) + 1 + sizeof(system_encoded);
+        memcpy(&legacy_payload[sizeof(header) + 1], &system_encoded, sizeof(system_encoded));
+        legacy_length = sizeof(header) + 1 + sizeof(system_encoded);
 
-			break;
+        break;
 
-		case  4:
-			ODID_OperatorID_encoded operatorid_encoded;
-			memset(&operatorid_encoded, 0, sizeof(operatorid_encoded));
-			if (encodeOperatorIDMessage(&operatorid_encoded, &UAS_data.OperatorID) != ODID_SUCCESS) {
-				break;
-			}
+    case  4:
+        ODID_OperatorID_encoded operatorid_encoded;
+        memset(&operatorid_encoded, 0, sizeof(operatorid_encoded));
+        if (encodeOperatorIDMessage(&operatorid_encoded, &UAS_data.OperatorID) != ODID_SUCCESS) {
+            break;
+        }
 
-            memcpy(&legacy_payload[sizeof(header)], &msg_counters[ODID_MSG_COUNTER_OPERATOR_ID], 1); //set packet counter
-            msg_counters[ODID_MSG_COUNTER_OPERATOR_ID]++;
-            //msg_counters[ODID_MSG_COUNTER_OPERATOR_ID] %= 256; //likely not be needed as it is defined as uint_8
+        memcpy(&legacy_payload[sizeof(header)], &msg_counters[ODID_MSG_COUNTER_OPERATOR_ID], 1); //set packet counter
+        msg_counters[ODID_MSG_COUNTER_OPERATOR_ID]++;
+        //msg_counters[ODID_MSG_COUNTER_OPERATOR_ID] %= 256; //likely not be needed as it is defined as uint_8
 
-			memcpy(&legacy_payload[sizeof(header) + 1], &operatorid_encoded, sizeof(operatorid_encoded));
-            legacy_length = sizeof(header) + 1 + sizeof(operatorid_encoded);
+        memcpy(&legacy_payload[sizeof(header) + 1], &operatorid_encoded, sizeof(operatorid_encoded));
+        legacy_length = sizeof(header) + 1 + sizeof(operatorid_encoded);
 
-			break;
-	}
+        break;
+    }
 
     legacy_phase++;
     legacy_phase %= 5;
 
-	advert.setAdvertisingData(0, legacy_length, legacy_payload);
+    advert.setAdvertisingData(0, legacy_length, legacy_payload);
 
     if (!started) {
         advert.start();

--- a/RemoteIDModule/BLE_TX.cpp
+++ b/RemoteIDModule/BLE_TX.cpp
@@ -8,6 +8,7 @@
  */
 
 #include "BLE_TX.h"
+#include "options.h"
 #include <esp_system.h>
 
 #include <BLEDevice.h>
@@ -16,52 +17,39 @@
 // set max power
 static const int8_t tx_power = ESP_PWR_LVL_P18;
 
-static esp_ble_gap_ext_adv_params_t ext_adv_params_1M = {
-    .type = ESP_BLE_GAP_SET_EXT_ADV_PROP_CONNECTABLE,
-    .interval_min = 0x30,
-    .interval_max = 0x30,
+//interval min/max are configured for 1 Hz update rate. Somehow dynamic setting of these fields fails
+//shorter intervals lead to more BLE transmissions. This would result in increased power consumption and can lead to more interference to other radio systems.
+static esp_ble_gap_ext_adv_params_t legacy_adv_params = {
+    .type = ESP_BLE_GAP_SET_EXT_ADV_PROP_LEGACY_NONCONN,
+    .interval_min = 125, //(unsigned int) 0.75*1000/(OUTPUT_RATE_HZ*6); //allow ble controller to have some room for transmission.
+    .interval_max = 167, //(unsigned int) 1000/(OUTPUT_RATE_HZ*6);
     .channel_map = ADV_CHNL_ALL,
     .own_addr_type = BLE_ADDR_TYPE_RANDOM,
-    .filter_policy = ADV_FILTER_ALLOW_SCAN_ANY_CON_ANY,
+    .filter_policy = ADV_FILTER_ALLOW_SCAN_ANY_CON_WLST, // we want unicast non-connectable transmission
     .tx_power = tx_power,
-    .primary_phy = ESP_BLE_GAP_PHY_CODED,
+    .primary_phy = ESP_BLE_GAP_PHY_1M,
     .max_skip = 0,
     .secondary_phy = ESP_BLE_GAP_PHY_1M,
     .sid = 0,
     .scan_req_notif = false,
 };
 
-static esp_ble_gap_ext_adv_params_t legacy_adv_params = {
-    .type = ESP_BLE_GAP_SET_EXT_ADV_PROP_LEGACY_IND,
-    .interval_min = 0x45,
-    .interval_max = 0x45,
-    .channel_map = ADV_CHNL_ALL,
-    .own_addr_type = BLE_ADDR_TYPE_RANDOM,
-    .filter_policy = ADV_FILTER_ALLOW_SCAN_ANY_CON_ANY,
-    .tx_power = tx_power,
-    .primary_phy = ESP_BLE_GAP_PHY_1M,
-    .max_skip = 0,
-    .secondary_phy = ESP_BLE_GAP_PHY_1M,
-    .sid = 2,
-    .scan_req_notif = false,
-};
-
 static esp_ble_gap_ext_adv_params_t ext_adv_params_coded = {
-    .type = ESP_BLE_GAP_SET_EXT_ADV_PROP_SCANNABLE,
-    .interval_min = 0x50,
-    .interval_max = 0x50,
+    .type = ESP_BLE_GAP_SET_EXT_ADV_PROP_NONCONN_NONSCANNABLE_UNDIRECTED, //set to unicast advertising
+     .interval_min = 750, //(unsigned int) 0.75*1000/(OUTPUT_RATE_HZ); //allow ble controller to have some room for transmission.
+    .interval_max = 1000, // (unsigned int) 1000/(OUTPUT_RATE_HZ);
     .channel_map = ADV_CHNL_ALL,
     .own_addr_type = BLE_ADDR_TYPE_RANDOM,
-    .filter_policy = ADV_FILTER_ALLOW_SCAN_ANY_CON_ANY,
+    .filter_policy = ADV_FILTER_ALLOW_SCAN_ANY_CON_WLST, // we want unicast non-connectable transmission
     .tx_power = tx_power,
-    .primary_phy = ESP_BLE_GAP_PHY_1M,
+    .primary_phy = ESP_BLE_GAP_PHY_CODED,
     .max_skip = 0,
     .secondary_phy = ESP_BLE_GAP_PHY_CODED,
-    .sid = 3,
+    .sid = 1,
     .scan_req_notif = false,
 };
 
-static BLEMultiAdvertising advert(3);
+static BLEMultiAdvertising advert(2);
 
 bool BLE_TX::init(void)
 {
@@ -75,64 +63,148 @@ bool BLE_TX::init(void)
     // set as a bluetooth random static address
     mac_addr[0] |= 0xc0;
 
-    advert.setAdvertisingParams(0, &ext_adv_params_1M);
+    advert.setAdvertisingParams(0, &legacy_adv_params);
     advert.setInstanceAddress(0, mac_addr);
     advert.setDuration(0);
 
-    advert.setAdvertisingParams(1, &legacy_adv_params);
-    advert.setInstanceAddress(1, mac_addr);
+    advert.setAdvertisingParams(1, &ext_adv_params_coded);
     advert.setDuration(1);
-
-    advert.setAdvertisingParams(2, &ext_adv_params_coded);
-    advert.setDuration(2);
-    advert.setInstanceAddress(2, mac_addr);
+    advert.setInstanceAddress(1, mac_addr);
 
     // prefer S8 coding
     if (esp_ble_gap_set_prefered_default_phy(ESP_BLE_GAP_PHY_OPTIONS_PREF_S8_CODING, ESP_BLE_GAP_PHY_OPTIONS_PREF_S8_CODING) != ESP_OK) {
         Serial.printf("Failed to setup S8 coding\n");
     }
 
+    legacy_msg_counter = 0;
+    longrange_msg_counter = 0;
     return true;
 }
 
 #define IMIN(a,b) ((a)<(b)?(a):(b))
 
-bool BLE_TX::transmit(ODID_UAS_Data &UAS_data)
+bool BLE_TX::transmit_longrange(ODID_UAS_Data &UAS_data)
 {
     // create a packed UAS data message
+    uint8_t payload[250];
     int length = odid_message_build_pack(&UAS_data, payload, 255);
     if (length <= 0) {
         return false;
     }
 
     // setup ASTM header
-    const uint8_t header[] { uint8_t(length+5), 0x16, 0xfa, 0xff, 0x0d, uint8_t(msg_counter++) };
+    const uint8_t header[] { uint8_t(length+5), 0x16, 0xfa, 0xff, 0x0d, uint8_t(longrange_msg_counter++) };
 
     // combine header with payload
-    memcpy(payload2, header, sizeof(header));
-    memcpy(&payload2[sizeof(header)], payload, length);
-    int length2 = sizeof(header) + length;
+    memcpy(longrange_payload, header, sizeof(header));
+    memcpy(&longrange_payload[sizeof(header)], payload, length);
+    int longrange_length = sizeof(header) + length;
 
-    char legacy_name[28] {};
-    const char *UAS_ID = (const char *)UAS_data.BasicID[0].UASID;
-    const uint8_t ID_len = strlen(UAS_ID);
-    const uint8_t ID_tail = IMIN(4, ID_len);
-    snprintf(legacy_name, sizeof(legacy_name), "DroneBeacon_%s", &UAS_ID[ID_len-ID_tail]);
-
-    memset(legacy_payload, 0, sizeof(legacy_payload));
-    const uint8_t legacy_header[] { 0x02, 0x01, 0x06, uint8_t(strlen(legacy_name)+1), ESP_BLE_AD_TYPE_NAME_SHORT};
-
-    memcpy(legacy_payload, legacy_header, sizeof(legacy_header));
-    memcpy(&legacy_payload[sizeof(legacy_header)], legacy_name, strlen(legacy_name));
-    const uint8_t legacy_length = sizeof(legacy_header) + strlen(legacy_name);
-    
-    // setup advertising data
-    advert.setAdvertisingData(0, length2, payload2);
-    advert.setScanRspData(1, legacy_length, legacy_payload);
-    advert.setAdvertisingData(1, legacy_length, legacy_payload);
-    advert.setScanRspData(2, length2, payload2);
+    advert.setAdvertisingData(1, longrange_length, longrange_payload);
 
     // we start advertising when we have the first lot of data to send
+    if (!started) {
+        advert.start();
+    }
+    started = true;
+
+    return true;
+}
+
+ bool BLE_TX::transmit_legacy(ODID_UAS_Data &UAS_data)
+ {
+	static uint8_t legacy_phase = 0;
+	int legacy_length = 0;
+	// setup ASTM header
+	const uint8_t header[] { 0x1e, 0x16, 0xfa, 0xff, 0x0d, uint8_t(legacy_msg_counter++) };
+	// combine header with payload
+	memset(legacy_payload, 0, sizeof(legacy_payload));
+	memcpy(legacy_payload, header, sizeof(header));
+
+	switch (legacy_phase)
+    {
+		case  0:
+			ODID_Location_encoded location_encoded;
+			memset(&location_encoded, 0, sizeof(location_encoded));
+			if (encodeLocationMessage(&location_encoded, &UAS_data.Location) != ODID_SUCCESS) {
+				break;
+			}
+
+			memcpy(&legacy_payload[sizeof(header)], &location_encoded, sizeof(location_encoded));
+			legacy_length = sizeof(header) + sizeof(location_encoded);
+
+			break;
+
+		case  1:
+			ODID_BasicID_encoded basicid_encoded;
+			memset(&basicid_encoded, 0, sizeof(basicid_encoded));
+			if (encodeBasicIDMessage(&basicid_encoded, &UAS_data.BasicID[0]) != ODID_SUCCESS) {
+				break;
+			}
+
+			memcpy(&legacy_payload[sizeof(header)], &basicid_encoded, sizeof(basicid_encoded));
+			legacy_length = sizeof(header) + sizeof(basicid_encoded);
+
+			break;
+
+		case  2:
+			ODID_SelfID_encoded selfid_encoded;
+			memset(&selfid_encoded, 0, sizeof(selfid_encoded));
+			if (encodeSelfIDMessage(&selfid_encoded, &UAS_data.SelfID) != ODID_SUCCESS) {
+				break;
+			}
+
+			memcpy(&legacy_payload[sizeof(header)], &selfid_encoded, sizeof(selfid_encoded));
+			legacy_length = sizeof(header) + sizeof(selfid_encoded);
+
+			break;
+
+		case  3:
+			ODID_System_encoded system_encoded;
+			memset(&system_encoded, 0, sizeof(system_encoded));
+			if (encodeSystemMessage(&system_encoded, &UAS_data.System) != ODID_SUCCESS) {
+				break;
+			}
+
+			memcpy(&legacy_payload[sizeof(header)], &system_encoded, sizeof(system_encoded));
+			legacy_length = sizeof(header) + sizeof(system_encoded);
+
+			break;
+
+		case  4:
+			ODID_OperatorID_encoded operatorid_encoded;
+			memset(&operatorid_encoded, 0, sizeof(operatorid_encoded));
+			if (encodeOperatorIDMessage(&operatorid_encoded, &UAS_data.OperatorID) != ODID_SUCCESS) {
+				break;
+			}
+
+			memcpy(&legacy_payload[sizeof(header)], &operatorid_encoded, sizeof(operatorid_encoded));
+			legacy_length = sizeof(header) + sizeof(operatorid_encoded);
+
+			break;
+
+		case  5: //broadcast BLE name
+			char legacy_name[28] {};
+			const char *UAS_ID = (const char *)UAS_data.BasicID[0].UASID;
+			const uint8_t ID_len = strlen(UAS_ID);
+			const uint8_t ID_tail = IMIN(4, ID_len);
+			snprintf(legacy_name, sizeof(legacy_name), "ArduRemoteID_%s", &UAS_ID[ID_len-ID_tail]);
+
+			memset(legacy_payload, 0, sizeof(legacy_payload));
+			const uint8_t legacy_header_ble_name[] { 0x02, 0x01, 0x06, uint8_t(strlen(legacy_name)+1), ESP_BLE_AD_TYPE_NAME_SHORT};
+
+			memcpy(legacy_payload, legacy_header_ble_name, sizeof(legacy_header_ble_name));
+			memcpy(&legacy_payload[sizeof(legacy_header_ble_name)], legacy_name, strlen(legacy_name) + 1);
+			legacy_length = sizeof(legacy_header_ble_name) + strlen(legacy_name);
+
+			break;
+	}
+
+	legacy_phase++;
+    legacy_phase %= 6;
+
+	advert.setAdvertisingData(0, legacy_length, legacy_payload);
+
     if (!started) {
         advert.start();
     }

--- a/RemoteIDModule/BLE_TX.cpp
+++ b/RemoteIDModule/BLE_TX.cpp
@@ -37,7 +37,7 @@ static esp_ble_gap_ext_adv_params_t legacy_adv_params = {
 static esp_ble_gap_ext_adv_params_t ext_adv_params_coded = {
     .type = ESP_BLE_GAP_SET_EXT_ADV_PROP_NONCONN_NONSCANNABLE_UNDIRECTED, //set to unicast advertising
      .interval_min = 1200, //(unsigned int) 0.75*1000/(OUTPUT_RATE_HZ)/0.625; //allow ble controller to have some room for transmission.
-    .interval_max = 1600, // (unsigned int) 1000/(OUTPUT_RATE_HZ)/0.625;
+    .interval_max = 1600, //(unsigned int) 1000/(OUTPUT_RATE_HZ)/0.625;
     .channel_map = ADV_CHNL_ALL,
     .own_addr_type = BLE_ADDR_TYPE_RANDOM,
     .filter_policy = ADV_FILTER_ALLOW_SCAN_ANY_CON_WLST, // we want unicast non-connectable transmission
@@ -49,7 +49,22 @@ static esp_ble_gap_ext_adv_params_t ext_adv_params_coded = {
     .scan_req_notif = false,
 };
 
-static BLEMultiAdvertising advert(2);
+static esp_ble_gap_ext_adv_params_t blename_adv_params = {
+    .type = ESP_BLE_GAP_SET_EXT_ADV_PROP_LEGACY_NONCONN,
+    .interval_min = 1200, //(unsigned int) 0.75*1000/(OUTPUT_RATE_HZ)/0.625; //allow ble controller to have some room for transmission.
+    .interval_max = 1600,//(unsigned int) 1000/(OUTPUT_RATE_HZ)/0.625;;
+    .channel_map = ADV_CHNL_ALL,
+    .own_addr_type = BLE_ADDR_TYPE_RANDOM,
+    .filter_policy = ADV_FILTER_ALLOW_SCAN_ANY_CON_WLST, // we want unicast non-connectable transmission
+    .tx_power = tx_power,
+    .primary_phy = ESP_BLE_GAP_PHY_1M,
+    .max_skip = 0,
+    .secondary_phy = ESP_BLE_GAP_PHY_1M,
+    .sid = 2,
+    .scan_req_notif = false,
+};
+
+static BLEMultiAdvertising advert(3);
 
 bool BLE_TX::init(void)
 {
@@ -71,17 +86,43 @@ bool BLE_TX::init(void)
     advert.setDuration(1);
     advert.setInstanceAddress(1, mac_addr);
 
+    advert.setAdvertisingParams(2, &blename_adv_params);
+    advert.setDuration(2);
+    advert.setInstanceAddress(2, mac_addr);
+
     // prefer S8 coding
     if (esp_ble_gap_set_prefered_default_phy(ESP_BLE_GAP_PHY_OPTIONS_PREF_S8_CODING, ESP_BLE_GAP_PHY_OPTIONS_PREF_S8_CODING) != ESP_OK) {
         Serial.printf("Failed to setup S8 coding\n");
     }
 
-    legacy_msg_counter = 0;
-    longrange_msg_counter = 0;
+    memset(&msg_counters,0, sizeof(msg_counters));
     return true;
 }
 
 #define IMIN(a,b) ((a)<(b)?(a):(b))
+
+bool BLE_TX::transmit_legacy_name(ODID_UAS_Data &UAS_data)
+{
+    //set BLE name
+    uint8_t legacy_name_payload[36];
+    char legacy_name[28] {};
+    const char *UAS_ID = (const char *)UAS_data.BasicID[0].UASID;
+    const uint8_t ID_len = strlen(UAS_ID);
+    const uint8_t ID_tail = IMIN(4, ID_len);
+    snprintf(legacy_name, sizeof(legacy_name), "ArduRemoteID_%s", &UAS_ID[ID_len-ID_tail]);
+
+    memset(legacy_name_payload, 0, sizeof(legacy_name_payload));
+    const uint8_t legacy_name_header[] { 0x02, 0x01, 0x06, uint8_t(strlen(legacy_name)+1), ESP_BLE_AD_TYPE_NAME_SHORT};
+
+    memcpy(legacy_name_payload, legacy_name_header, sizeof(legacy_name_header));
+    memcpy(&legacy_name_payload[sizeof(legacy_name_header)], legacy_name, strlen(legacy_name) + 1);
+
+    int legacy_length = sizeof(legacy_name_header) + strlen(legacy_name) + 1; //add extra char for \0
+
+    advert.setAdvertisingData(2, legacy_length, legacy_payload);
+
+    return true;
+}
 
 bool BLE_TX::transmit_longrange(ODID_UAS_Data &UAS_data)
 {
@@ -93,7 +134,7 @@ bool BLE_TX::transmit_longrange(ODID_UAS_Data &UAS_data)
     }
 
     // setup ASTM header
-    const uint8_t header[] { uint8_t(length+5), 0x16, 0xfa, 0xff, 0x0d, uint8_t(longrange_msg_counter++) };
+    const uint8_t header[] { uint8_t(length+5), 0x16, 0xfa, 0xff, 0x0d, uint8_t(msg_counters[ODID_MSG_COUNTER_PACKED]++) };
 
     // combine header with payload
     memcpy(longrange_payload, header, sizeof(header));
@@ -116,10 +157,10 @@ bool BLE_TX::transmit_longrange(ODID_UAS_Data &UAS_data)
 	static uint8_t legacy_phase = 0;
 	int legacy_length = 0;
 	// setup ASTM header
-	const uint8_t header[] { 0x1e, 0x16, 0xfa, 0xff, 0x0d, uint8_t(legacy_msg_counter++) };
+	const uint8_t header[] { 0x1e, 0x16, 0xfa, 0xff, 0x0d }; //exclude the message counter
 	// combine header with payload
 	memset(legacy_payload, 0, sizeof(legacy_payload));
-	memcpy(legacy_payload, header, sizeof(header));
+    memcpy(legacy_payload, header, sizeof(header));
 
 	switch (legacy_phase)
     {
@@ -130,8 +171,12 @@ bool BLE_TX::transmit_longrange(ODID_UAS_Data &UAS_data)
 				break;
 			}
 
-			memcpy(&legacy_payload[sizeof(header)], &location_encoded, sizeof(location_encoded));
-			legacy_length = sizeof(header) + sizeof(location_encoded);
+            memcpy(&legacy_payload[sizeof(header)], &msg_counters[ODID_MSG_COUNTER_LOCATION], 1); //set packet counter
+            msg_counters[ODID_MSG_COUNTER_LOCATION]++;
+            //msg_counters[ODID_MSG_COUNTER_LOCATION] %= 256; //likely not be needed as it is defined as unint_8
+
+			memcpy(&legacy_payload[sizeof(header) + 1], &location_encoded, sizeof(location_encoded));
+			legacy_length = sizeof(header) + 1 + sizeof(location_encoded);
 
 			break;
 
@@ -142,8 +187,12 @@ bool BLE_TX::transmit_longrange(ODID_UAS_Data &UAS_data)
 				break;
 			}
 
-			memcpy(&legacy_payload[sizeof(header)], &basicid_encoded, sizeof(basicid_encoded));
-			legacy_length = sizeof(header) + sizeof(basicid_encoded);
+            memcpy(&legacy_payload[sizeof(header)], &msg_counters[ODID_MSG_COUNTER_BASIC_ID], 1); //set packet counter
+            msg_counters[ODID_MSG_COUNTER_BASIC_ID]++;
+            //msg_counters[ODID_MSG_COUNTER_BASIC_ID] %= 256; //likely not be needed as it is defined as unint_8
+
+			memcpy(&legacy_payload[sizeof(header) + 1], &basicid_encoded, sizeof(basicid_encoded));
+            legacy_length = sizeof(header) + 1 + sizeof(basicid_encoded);
 
 			break;
 
@@ -154,8 +203,12 @@ bool BLE_TX::transmit_longrange(ODID_UAS_Data &UAS_data)
 				break;
 			}
 
-			memcpy(&legacy_payload[sizeof(header)], &selfid_encoded, sizeof(selfid_encoded));
-			legacy_length = sizeof(header) + sizeof(selfid_encoded);
+            memcpy(&legacy_payload[sizeof(header)], &msg_counters[ODID_MSG_COUNTER_SELF_ID], 1); //set packet counter
+            msg_counters[ODID_MSG_COUNTER_SELF_ID]++;
+            //msg_counters[ODID_MSG_COUNTER_SELF_ID] %= 256; //likely not be needed as it is defined as uint_8
+
+			memcpy(&legacy_payload[sizeof(header) + 1], &selfid_encoded, sizeof(selfid_encoded));
+            legacy_length = sizeof(header) + 1 + sizeof(selfid_encoded);
 
 			break;
 
@@ -166,8 +219,12 @@ bool BLE_TX::transmit_longrange(ODID_UAS_Data &UAS_data)
 				break;
 			}
 
-			memcpy(&legacy_payload[sizeof(header)], &system_encoded, sizeof(system_encoded));
-			legacy_length = sizeof(header) + sizeof(system_encoded);
+            memcpy(&legacy_payload[sizeof(header)], &msg_counters[ODID_MSG_COUNTER_SYSTEM], 1); //set packet counter
+            msg_counters[ODID_MSG_COUNTER_SYSTEM]++;
+            //msg_counters[ODID_MSG_COUNTER_SYSTEM] %= 256; //likely not be needed as it is defined as uint_8
+
+			memcpy(&legacy_payload[sizeof(header) + 1], &system_encoded, sizeof(system_encoded));
+            legacy_length = sizeof(header) + 1 + sizeof(system_encoded);
 
 			break;
 
@@ -178,30 +235,18 @@ bool BLE_TX::transmit_longrange(ODID_UAS_Data &UAS_data)
 				break;
 			}
 
-			memcpy(&legacy_payload[sizeof(header)], &operatorid_encoded, sizeof(operatorid_encoded));
-			legacy_length = sizeof(header) + sizeof(operatorid_encoded);
+            memcpy(&legacy_payload[sizeof(header)], &msg_counters[ODID_MSG_COUNTER_OPERATOR_ID], 1); //set packet counter
+            msg_counters[ODID_MSG_COUNTER_OPERATOR_ID]++;
+            //msg_counters[ODID_MSG_COUNTER_OPERATOR_ID] %= 256; //likely not be needed as it is defined as uint_8
 
-			break;
-
-		case  5: //broadcast BLE name
-			char legacy_name[28] {};
-			const char *UAS_ID = (const char *)UAS_data.BasicID[0].UASID;
-			const uint8_t ID_len = strlen(UAS_ID);
-			const uint8_t ID_tail = IMIN(4, ID_len);
-			snprintf(legacy_name, sizeof(legacy_name), "ArduRemoteID_%s", &UAS_ID[ID_len-ID_tail]);
-
-			memset(legacy_payload, 0, sizeof(legacy_payload));
-			const uint8_t legacy_header_ble_name[] { 0x02, 0x01, 0x06, uint8_t(strlen(legacy_name)+1), ESP_BLE_AD_TYPE_NAME_SHORT};
-
-			memcpy(legacy_payload, legacy_header_ble_name, sizeof(legacy_header_ble_name));
-			memcpy(&legacy_payload[sizeof(legacy_header_ble_name)], legacy_name, strlen(legacy_name) + 1);
-			legacy_length = sizeof(legacy_header_ble_name) + strlen(legacy_name);
+			memcpy(&legacy_payload[sizeof(header) + 1], &operatorid_encoded, sizeof(operatorid_encoded));
+            legacy_length = sizeof(header) + 1 + sizeof(operatorid_encoded);
 
 			break;
 	}
 
-	legacy_phase++;
-    legacy_phase %= 6;
+    legacy_phase++;
+    legacy_phase %= 5;
 
 	advert.setAdvertisingData(0, legacy_length, legacy_payload);
 

--- a/RemoteIDModule/BLE_TX.cpp
+++ b/RemoteIDModule/BLE_TX.cpp
@@ -21,8 +21,8 @@ static const int8_t tx_power = ESP_PWR_LVL_P18;
 //shorter intervals lead to more BLE transmissions. This would result in increased power consumption and can lead to more interference to other radio systems.
 static esp_ble_gap_ext_adv_params_t legacy_adv_params = {
     .type = ESP_BLE_GAP_SET_EXT_ADV_PROP_LEGACY_NONCONN,
-    .interval_min = 125, //(unsigned int) 0.75*1000/(OUTPUT_RATE_HZ*6); //allow ble controller to have some room for transmission.
-    .interval_max = 167, //(unsigned int) 1000/(OUTPUT_RATE_HZ*6);
+    .interval_min = 192, //(unsigned int) 0.75*1000/(OUTPUT_RATE_HZ*6)/0.625; //allow ble controller to have some room for transmission.
+    .interval_max = 267, //(unsigned int) 1000/(OUTPUT_RATE_HZ*6)/0.625;
     .channel_map = ADV_CHNL_ALL,
     .own_addr_type = BLE_ADDR_TYPE_RANDOM,
     .filter_policy = ADV_FILTER_ALLOW_SCAN_ANY_CON_WLST, // we want unicast non-connectable transmission
@@ -36,8 +36,8 @@ static esp_ble_gap_ext_adv_params_t legacy_adv_params = {
 
 static esp_ble_gap_ext_adv_params_t ext_adv_params_coded = {
     .type = ESP_BLE_GAP_SET_EXT_ADV_PROP_NONCONN_NONSCANNABLE_UNDIRECTED, //set to unicast advertising
-     .interval_min = 750, //(unsigned int) 0.75*1000/(OUTPUT_RATE_HZ); //allow ble controller to have some room for transmission.
-    .interval_max = 1000, // (unsigned int) 1000/(OUTPUT_RATE_HZ);
+     .interval_min = 1200, //(unsigned int) 0.75*1000/(OUTPUT_RATE_HZ)/0.625; //allow ble controller to have some room for transmission.
+    .interval_max = 1600, // (unsigned int) 1000/(OUTPUT_RATE_HZ)/0.625;
     .channel_map = ADV_CHNL_ALL,
     .own_addr_type = BLE_ADDR_TYPE_RANDOM,
     .filter_policy = ADV_FILTER_ALLOW_SCAN_ANY_CON_WLST, // we want unicast non-connectable transmission

--- a/RemoteIDModule/BLE_TX.h
+++ b/RemoteIDModule/BLE_TX.h
@@ -10,11 +10,11 @@ class BLE_TX {
 public:
     bool init(void);
     bool transmit_longrange(ODID_UAS_Data &UAS_data);
+    bool transmit_legacy_name(ODID_UAS_Data &UAS_data);
     bool transmit_legacy(ODID_UAS_Data &UAS_data);
 
 private:
-    uint8_t legacy_msg_counter;
-    uint8_t longrange_msg_counter;
+    uint8_t msg_counters[ODID_MSG_COUNTER_AMOUNT];
     uint8_t legacy_payload[36];
     uint8_t longrange_payload[250];
     bool started;

--- a/RemoteIDModule/BLE_TX.h
+++ b/RemoteIDModule/BLE_TX.h
@@ -9,12 +9,13 @@
 class BLE_TX {
 public:
     bool init(void);
-    bool transmit(ODID_UAS_Data &UAS_data);
+    bool transmit_longrange(ODID_UAS_Data &UAS_data);
+    bool transmit_legacy(ODID_UAS_Data &UAS_data);
 
 private:
-    int msg_counter;
-    uint8_t payload[250];
-    uint8_t payload2[255];
+    uint8_t legacy_msg_counter;
+    uint8_t longrange_msg_counter;
     uint8_t legacy_payload[36];
+    uint8_t longrange_payload[250];
     bool started;
 };

--- a/RemoteIDModule/CANDriver.cpp
+++ b/RemoteIDModule/CANDriver.cpp
@@ -42,7 +42,8 @@ static const twai_general_config_t g_config =                      {.mode = TWAI
                                                                     .clkout_io = TWAI_IO_UNUSED, .bus_off_io = TWAI_IO_UNUSED,      \
                                                                     .tx_queue_len = 5, .rx_queue_len = 5,                           \
                                                                     .alerts_enabled = TWAI_ALERT_NONE,  .clkout_divider = 0,        \
-                                                                    .intr_flags = ESP_INTR_FLAG_LEVEL2};
+                                                                    .intr_flags = ESP_INTR_FLAG_LEVEL2
+                                                                   };
 
 static const twai_timing_config_t t_config = TWAI_TIMING_CONFIG_1MBITS();
 static const twai_filter_config_t f_config = TWAI_FILTER_CONFIG_ACCEPT_ALL();
@@ -66,8 +67,8 @@ void CANDriver::init_once(bool enable_irq)
     } else {
         Serial.printf("Failed to reconfigure CAN/TWAI alerts");
     }
-    
-     //Start TWAI driver
+
+    //Start TWAI driver
     if (twai_start() == ESP_OK)
     {
         Serial.printf("CAN/TWAI Driver started\n");

--- a/RemoteIDModule/CANDriver.h
+++ b/RemoteIDModule/CANDriver.h
@@ -8,7 +8,7 @@ public:
 
     bool send(const CANFrame &frame);
     bool receive(CANFrame &out_frame);
-    
+
 private:
     struct Timings {
         uint16_t prescaler;
@@ -50,12 +50,12 @@ struct CANFrame {
     };
     uint8_t dlc;                ///< Data Length Code
 
-CANFrame() :
-    id(0),
+    CANFrame() :
+        id(0),
         dlc(0)
-        {
-            memset(data,0, MaxDataLen);
-        }
+    {
+        memset(data,0, MaxDataLen);
+    }
 
     CANFrame(uint32_t can_id, const uint8_t* can_data, uint8_t data_len, bool canfd_frame = false);
 

--- a/RemoteIDModule/DroneCAN.cpp
+++ b/RemoteIDModule/DroneCAN.cpp
@@ -27,8 +27,8 @@
 
 static void onTransferReceived_trampoline(CanardInstance* ins, CanardRxTransfer* transfer);
 static bool shouldAcceptTransfer_trampoline(const CanardInstance* ins, uint64_t* out_data_type_signature, uint16_t data_type_id,
-                                            CanardTransferType transfer_type,
-                                            uint8_t source_node_id);
+        CanardTransferType transfer_type,
+        uint8_t source_node_id);
 
 // decoded messages
 
@@ -104,7 +104,7 @@ void DroneCAN::onTransferReceived(CanardInstance* ins,
 {
     if (canardGetLocalNodeID(ins) == CANARD_BROADCAST_NODE_ID) {
         if (transfer->transfer_type == CanardTransferTypeBroadcast &&
-            transfer->data_type_id == UAVCAN_PROTOCOL_DYNAMIC_NODE_ID_ALLOCATION_ID) {
+                transfer->data_type_id == UAVCAN_PROTOCOL_DYNAMIC_NODE_ID_ALLOCATION_ID) {
             handle_allocation_response(ins, transfer);
         }
         return;
@@ -154,7 +154,7 @@ bool DroneCAN::shouldAcceptTransfer(const CanardInstance* ins,
                                     uint8_t source_node_id)
 {
     if (canardGetLocalNodeID(ins) == CANARD_BROADCAST_NODE_ID &&
-        data_type_id == UAVCAN_PROTOCOL_DYNAMIC_NODE_ID_ALLOCATION_ID) {
+            data_type_id == UAVCAN_PROTOCOL_DYNAMIC_NODE_ID_ALLOCATION_ID) {
         *out_data_type_signature = UAVCAN_PROTOCOL_DYNAMIC_NODE_ID_ALLOCATION_SIGNATURE;
         return true;
     }
@@ -175,7 +175,7 @@ bool DroneCAN::shouldAcceptTransfer(const CanardInstance* ins,
 }
 
 static void onTransferReceived_trampoline(CanardInstance* ins,
-                                          CanardRxTransfer* transfer)
+        CanardRxTransfer* transfer)
 {
     DroneCAN *dc = (DroneCAN *)ins->user_reference;
     dc->onTransferReceived(ins, transfer);
@@ -185,10 +185,10 @@ static void onTransferReceived_trampoline(CanardInstance* ins,
   see if we want to process this packet
  */
 static bool shouldAcceptTransfer_trampoline(const CanardInstance* ins,
-                                            uint64_t* out_data_type_signature,
-                                            uint16_t data_type_id,
-                                            CanardTransferType transfer_type,
-                                            uint8_t source_node_id)
+        uint64_t* out_data_type_signature,
+        uint16_t data_type_id,
+        CanardTransferType transfer_type,
+        uint8_t source_node_id)
 {
     DroneCAN *dc = (DroneCAN *)ins->user_reference;
     return dc->shouldAcceptTransfer(ins, out_data_type_signature,
@@ -239,13 +239,13 @@ void DroneCAN::processRx(void)
                       rx_frame.data_len,
                       err);
 #else
-        UNUSED(err);                      
+        UNUSED(err);
 #endif
     }
 }
 
 CANFrame::CANFrame(uint32_t can_id, const uint8_t* can_data, uint8_t data_len, bool canfd_frame) :
-        id(can_id)
+    id(can_id)
 {
     if ((can_data == nullptr) || (data_len == 0) || (data_len > MaxDataLen)) {
         return;
@@ -414,7 +414,7 @@ bool DroneCAN::do_DNA(void)
 
     static const uint8_t MaxLenOfUniqueIDInRequest = 6;
     uint8_t uid_size = (uint8_t)(sizeof(uavcan_protocol_dynamic_node_id_Allocation::unique_id.data) - node_id_allocation_unique_id_offset);
-    
+
     if (uid_size > MaxLenOfUniqueIDInRequest) {
         uid_size = MaxLenOfUniqueIDInRequest;
     }
@@ -534,7 +534,7 @@ void DroneCAN::handle_Location(CanardRxTransfer* transfer)
 #if 0
 // xprintf is useful when debugging in C code such as libcanard
 extern "C" {
-void xprintf(const char *fmt, ...);
+    void xprintf(const char *fmt, ...);
 }
 
 void xprintf(const char *fmt, ...)

--- a/RemoteIDModule/RemoteIDModule.ino
+++ b/RemoteIDModule/RemoteIDModule.ino
@@ -272,10 +272,18 @@ void loop()
         wifi.transmit(UAS_data);
     }
 #endif
-#if AP_BLE_LEGACY_ENABLED || AP_BLE_LONGRANGE_ENABLED
+
+#if AP_BLE_LONGRANGE_ENABLED
     if (loop_counter == 0) { //only run on the original update rate
         ble.transmit_longrange(UAS_data);
     }
+#endif
+
+#if AP_BLE_LEGACY_ENABLED
     ble.transmit_legacy(UAS_data);
+#endif
+
+#if AP_BLE_LEGACY_ENABLED || AP_BLE_LONGRANGE_ENABLED
+    ble.transmit_legacy_name(UAS_data);
 #endif
 }

--- a/RemoteIDModule/RemoteIDModule.ino
+++ b/RemoteIDModule/RemoteIDModule.ino
@@ -23,7 +23,7 @@ static DroneCAN dronecan;
 #endif
 
 #if AP_MAVLINK_ENABLED
-static MAVLinkSerial mavlink1{Serial1, MAVLINK_COMM_0};
+static MAVLinkSerial mavlink1 {Serial1, MAVLINK_COMM_0};
 static MAVLinkSerial mavlink2{Serial, MAVLINK_COMM_1};
 #endif
 
@@ -261,7 +261,7 @@ void loop()
 #endif
 
     if (last_location_ms == 0 ||
-        now_ms - last_location_ms > 5000) {
+            now_ms - last_location_ms > 5000) {
         UAS_data.Location.Status = ODID_STATUS_REMOTE_ID_SYSTEM_FAILURE;
     }
 

--- a/RemoteIDModule/WiFi_TX.cpp
+++ b/RemoteIDModule/WiFi_TX.cpp
@@ -16,7 +16,7 @@ bool WiFi_NAN::init(void)
     WiFi.softAP("", NULL, wifi_channel);
 
     esp_wifi_get_config(WIFI_IF_AP, &wifi_config);
-  
+
     wifi_config.ap.ssid_hidden = 1;
 
     if (esp_wifi_set_config(WIFI_IF_AP, &wifi_config) != ESP_OK) {
@@ -38,15 +38,15 @@ bool WiFi_NAN::transmit(ODID_UAS_Data &UAS_data)
 
     int length;
     if ((length = odid_wifi_build_nan_sync_beacon_frame((char *)WiFi_mac_addr,
-                                                        buffer,sizeof(buffer))) > 0) {
+                  buffer,sizeof(buffer))) > 0) {
         if (esp_wifi_80211_tx(WIFI_IF_AP,buffer,length,true) != ESP_OK) {
             return false;
         }
     }
 
     if ((length = odid_wifi_build_message_pack_nan_action_frame(&UAS_data,(char *)WiFi_mac_addr,
-                                                                ++send_counter,
-                                                                buffer,sizeof(buffer))) > 0) {
+                  ++send_counter,
+                  buffer,sizeof(buffer))) > 0) {
         if (esp_wifi_80211_tx(WIFI_IF_AP,buffer,length,true) != ESP_OK) {
             return false;
         }

--- a/RemoteIDModule/options.h
+++ b/RemoteIDModule/options.h
@@ -8,8 +8,9 @@
 // enable WiFi NAN support
 #define AP_WIFI_NAN_ENABLED 1
 
-// enable bluetooth 4 and 5 support
-#define AP_BLE_ENABLED 1
+// allow enabling legacy or long range only, or both
+#define AP_BLE_LEGACY_ENABLED 1 // bluetooth 4 legacy
+#define AP_BLE_LONGRANGE_ENABLED 1 // bluetooth 5 long range
 
 // start sending packets as soon we we power up,
 // not waiting for location data from flight controller
@@ -20,3 +21,6 @@
 
 // do we support MAVLink connnection to flight controller?
 #define AP_MAVLINK_ENABLED 1
+
+// define the output update rate
+#define OUTPUT_RATE_HZ 1 //this is the minimum update rate according to the docs. More transmissions will increase interferency to other radio modules.


### PR DESCRIPTION
Existing BLE code did work, but was not compliant:

- BLE legacy was not configured correctly, likely regular BLE 5 was used
- BLE Long Range, also the primary channels needs to be set to coded
- Reduced the update rate to the compliant update rate. A higher transmission rate will lead to more power consumption and may increase interference to other radio modules.