### PR TITLE
bug fix: extra BLE advertisement for BLE name broke all Bluetooth transmissions

### DIFF
--- a/RemoteIDModule/BLE_TX.h
+++ b/RemoteIDModule/BLE_TX.h
@@ -10,7 +10,6 @@ class BLE_TX {
 public:
     bool init(void);
     bool transmit_longrange(ODID_UAS_Data &UAS_data);
-    bool transmit_legacy_name(ODID_UAS_Data &UAS_data);
     bool transmit_legacy(ODID_UAS_Data &UAS_data);
 
 private:

--- a/RemoteIDModule/RemoteIDModule.ino
+++ b/RemoteIDModule/RemoteIDModule.ino
@@ -266,15 +266,10 @@ void loop()
         UAS_data.Location.Status = ODID_STATUS_REMOTE_ID_SYSTEM_FAILURE;
     }
 
-    if (last_system_ms == 0 ||
-        now_ms - last_system_ms > 5000) {
-        UAS_data.Location.Status = ODID_STATUS_REMOTE_ID_SYSTEM_FAILURE;
-    }
-
     if (transport.get_parse_fail() != nullptr) {
         UAS_data.Location.Status = ODID_STATUS_REMOTE_ID_SYSTEM_FAILURE;
     }
-    
+
     set_data(transport);
     last_update = now_ms;
 #if AP_WIFI_NAN_ENABLED
@@ -293,7 +288,4 @@ void loop()
     ble.transmit_legacy(UAS_data);
 #endif
 
-#if AP_BLE_LEGACY_ENABLED || AP_BLE_LONGRANGE_ENABLED
-    ble.transmit_legacy_name(UAS_data);
-#endif
 }


### PR DESCRIPTION
latest BLE change did introduce an extra BLE advertisement for broadcasting the BLE name. Although it seem trivial to me, this broke all BLE transmissions. In this code I have reverted to an older code state, which I can confirm BLE transmissions do work again.