### PR TITLE
WiFi NAN, bug fix transmit on channel 6, set to random MAC address

### DIFF
--- a/RemoteIDModule/BLE_TX.cpp
+++ b/RemoteIDModule/BLE_TX.cpp
@@ -72,9 +72,8 @@ bool BLE_TX::init(void)
 
     // generate random mac address
     uint8_t mac_addr[6];
-    for (uint8_t i=0; i<6; i++) {
-        mac_addr[i] = uint8_t(random(256));
-    }
+    generate_random_mac(mac_addr);
+
     // set as a bluetooth random static address
     mac_addr[0] |= 0xc0;
 

--- a/RemoteIDModule/BLE_TX.h
+++ b/RemoteIDModule/BLE_TX.h
@@ -3,12 +3,11 @@
  */
 #pragma once
 
-#include <Arduino.h>
-#include <opendroneid.h>
+#include "transmitter.h"
 
-class BLE_TX {
+class BLE_TX : public Transmitter {
 public:
-    bool init(void);
+    bool init(void) override;
     bool transmit_longrange(ODID_UAS_Data &UAS_data);
     bool transmit_legacy_name(ODID_UAS_Data &UAS_data);
     bool transmit_legacy(ODID_UAS_Data &UAS_data);

--- a/RemoteIDModule/WiFi_TX.cpp
+++ b/RemoteIDModule/WiFi_TX.cpp
@@ -12,15 +12,11 @@
 bool WiFi_NAN::init(void)
 {
     //use a local MAC address to avoid tracking transponders based on their MAC address
-    int i;
     uint8_t mac_addr[6];
-    for(i = 0 ; i < 6; i++ )
-	{
-		mac_addr[i] = rand() % 256;
-	}
+    generate_random_mac(mac_addr);
 
-	mac_addr[0] |= 0x02;  //set MAC local bit
-    mac_addr[0] &= 0xFE;  //unset MAC multicast bit
+    mac_addr[0] |= 0x02;  // set MAC local bit
+    mac_addr[0] &= 0xFE;  // unset MAC multicast bit
 
     //set MAC address
     esp_base_mac_addr_set(mac_addr);

--- a/RemoteIDModule/WiFi_TX.cpp
+++ b/RemoteIDModule/WiFi_TX.cpp
@@ -11,13 +11,28 @@
 
 bool WiFi_NAN::init(void)
 {
+    //use a local MAC address to avoid tracking transponders based on their MAC address
+    int i;
+    uint8_t mac_addr[6];
+    for(i = 0 ; i < 6; i++ )
+	{
+		mac_addr[i] = rand() % 256;
+	}
+
+	mac_addr[0] |= 0x02;  //set MAC local bit
+    mac_addr[0] &= 0xFE;  //unset MAC multicast bit
+
+    //set MAC address
+    esp_base_mac_addr_set(mac_addr);
+
     wifi_config_t wifi_config {};
 
-    WiFi.softAP("", NULL, wifi_channel);
+    WiFi.softAP("");
 
     esp_wifi_get_config(WIFI_IF_AP, &wifi_config);
 
     wifi_config.ap.ssid_hidden = 1;
+    wifi_config.ap.channel = wifi_channel;
 
     if (esp_wifi_set_config(WIFI_IF_AP, &wifi_config) != ESP_OK) {
         return false;

--- a/RemoteIDModule/WiFi_TX.h
+++ b/RemoteIDModule/WiFi_TX.h
@@ -3,12 +3,11 @@
  */
 #pragma once
 
-#include <Arduino.h>
-#include <opendroneid.h>
+#include "transmitter.h"
 
-class WiFi_NAN {
+class WiFi_NAN : public Transmitter {
 public:
-    bool init(void);
+    bool init(void) override;
     bool transmit(ODID_UAS_Data &UAS_data);
 
 private:

--- a/RemoteIDModule/transmitter.cpp
+++ b/RemoteIDModule/transmitter.cpp
@@ -1,0 +1,12 @@
+/*
+  common functions for all transmitter backends
+ */
+
+#include "transmitter.h"
+
+void Transmitter::generate_random_mac(uint8_t mac[6])
+{
+    for (uint8_t i=0; i<6; i++) {
+        mac[i] = uint8_t(random(256));
+    }
+}

--- a/RemoteIDModule/transmitter.h
+++ b/RemoteIDModule/transmitter.h
@@ -1,0 +1,15 @@
+/*
+  parent class for transmission methods
+ */
+#pragma once
+
+#include <Arduino.h>
+#include <opendroneid.h>
+
+class Transmitter {
+public:
+    virtual bool init(void);
+
+protected:
+    void generate_random_mac(uint8_t mac[6]);
+};


### PR DESCRIPTION
- existing code was transmitting NAN packets on channel 1. This should be channel 6 for NAN packets. Both verified with a wireshark capture
- changed the device MAC address to a local generated MAC address. This would have two benefits a) you can't track a transponder based on the MAC address b) related, typically the original MAC address is considered to be a privacy sensitive information element. So, using the original MAC address may cause issues with existing privacy laws (if you capture them by receivers). Using a local generated MAC address at every boot of the transmitter solves this.