### PR TITLE
db200: typo, termination resistors are GPIO 10

### DIFF
--- a/RemoteIDModule/board_config.h
+++ b/RemoteIDModule/board_config.h
@@ -28,7 +28,7 @@
 #define CAN_APP_NODE_NAME "BlueMark DB200"
 
 // to enable termination resistors uncomment this line
-//#define PIN_CAN_TERM EN_NUM_10 // if set to ON, the termination resistors of the CAN bus are enabled
+//#define PIN_CAN_TERM GPIO_NUM_10 // if set to ON, the termination resistors of the CAN bus are enabled
 
 #define PIN_UART_TX 3
 #define PIN_UART_RX 2


### PR DESCRIPTION
The termination resistors can be enabled by GPIO 10. Existing code had a typo.