### PR TITLE
allow user to set BLE TX power level

### DIFF
--- a/RemoteIDModule/BLE_TX.cpp
+++ b/RemoteIDModule/BLE_TX.cpp
@@ -15,7 +15,7 @@
 #include <BLEAdvertising.h>
 
 // set max power
-static const int8_t tx_power = ESP_PWR_LVL_P18;
+static int8_t tx_power = ESP_PWR_LVL_P18;
 
 //interval min/max are configured for 1 Hz update rate. Somehow dynamic setting of these fields fails
 //shorter intervals lead to more BLE transmissions. This would result in increased power consumption and can lead to more interference to other radio systems.
@@ -68,6 +68,8 @@ static BLEMultiAdvertising advert(3);
 
 bool BLE_TX::init(void)
 {
+    set_tx_power_level();
+
     BLEDevice::init("");
 
     // generate random mac address
@@ -95,6 +97,37 @@ bool BLE_TX::init(void)
     }
 
     memset(&msg_counters,0, sizeof(msg_counters));
+    return true;
+}
+
+bool BLE_TX::set_tx_power_level()
+{
+    int esp_power_level = ESP_PWR_LVL_P18;
+
+    //use switch to determine the ESP power level ENUM
+    switch (AP_BLE_TX_POWER)
+    {
+        case BLE_PWR_P9_DBM:
+            esp_power_level = ESP_PWR_LVL_P9;
+            break;
+        case BLE_PWR_P12_DBM:
+            esp_power_level = ESP_PWR_LVL_P12;
+            break;
+        case BLE_PWR_P15_DBM:
+            esp_power_level = ESP_PWR_LVL_P15;
+            break;
+        case BLE_PWR_P18_DBM:
+            esp_power_level = ESP_PWR_LVL_P18;
+            break;
+        default:
+          esp_power_level = ESP_PWR_LVL_P18;
+    }
+
+    tx_power = esp_power_level;
+    legacy_adv_params.tx_power = esp_power_level;
+    ext_adv_params_coded.tx_power = esp_power_level;
+    blename_adv_params.tx_power = esp_power_level;
+
     return true;
 }
 

--- a/RemoteIDModule/BLE_TX.h
+++ b/RemoteIDModule/BLE_TX.h
@@ -5,9 +5,12 @@
 
 #include "transmitter.h"
 
+enum BLE_power_level { BLE_PWR_P9_DBM, BLE_PWR_P12_DBM, BLE_PWR_P15_DBM, BLE_PWR_P18_DBM };
+
 class BLE_TX : public Transmitter {
 public:
     bool init(void) override;
+    bool set_tx_power_level();
     bool transmit_longrange(ODID_UAS_Data &UAS_data);
     bool transmit_legacy_name(ODID_UAS_Data &UAS_data);
     bool transmit_legacy(ODID_UAS_Data &UAS_data);

--- a/RemoteIDModule/options.h
+++ b/RemoteIDModule/options.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "board_config.h"
+#include "BLE_TX.h"
 
 // enable WiFi NAN support
 #define AP_WIFI_NAN_ENABLED 1
@@ -11,6 +12,8 @@
 // allow enabling legacy or long range only, or both
 #define AP_BLE_LEGACY_ENABLED 1 // bluetooth 4 legacy
 #define AP_BLE_LONGRANGE_ENABLED 1 // bluetooth 5 long range
+
+#define AP_BLE_TX_POWER BLE_PWR_P18_DBM //set power level for BLE transmissions: BLE_PWR_P9_DBM, BLE_PWR_P12_DBM, BLE_PWR_P15_DBM or  BLE_PWR_P18_DBM
 
 // start sending packets as soon we we power up,
 // not waiting for location data from flight controller


### PR DESCRIPTION
The ESP modules can have BLE transmissions with +18 dBm, whereas modules of other vendors only allow +8 dBm transmit power or even less. Also, from a regulatory point of view, the ESP TX power can be lower.

This PR allows to set the BLE TX power in the options.h file. This can be useful in case there is interference, or if power consumption is important. 

The module allows a very large range of power settings. To prevent that the user configures an power level that is non-compliant, in this PR an auxiliary enum is used to allow only power levels ranging from +9 dBm to 18 dBm.