### PR TITLE
Set heartbeat autopilot correctly

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -36,8 +36,10 @@ or build with the Arduino GUI. I prefer make, but both will work.
  - cd RemoteIDModule
  - make upload
 
-If board does not flash, hold-down BOOT pushbutton on pcb while pressing RESET pushbutton briefly [to force it into bootloader mode] and retry.
-done, ESP32-S3 is now running and emitting test/demo remote-id bluetooth
+If the board does not flash, hold-down the BOOT pushbutton on the PCB while pressing the RESET pushbutton briefly [to force it into bootloader mode] and retry.
+The ESP32-S3 is now running and emitting test/demo remote-id bluetooth
+
+If you get an error about missing serial support from python, install it with `python -m pip install pyserial`.
 
 ## Building with the Arduino GUI
 

--- a/RemoteIDModule/mavlink.cpp
+++ b/RemoteIDModule/mavlink.cpp
@@ -62,7 +62,7 @@ void MAVLinkSerial::update_send(void)
         mavlink_msg_heartbeat_send(
             chan,
             MAV_TYPE_ODID,
-            MAV_AUTOPILOT_ARDUPILOTMEGA,
+            MAV_AUTOPILOT_INVALID,
             0,
             0,
             0);

--- a/scripts/install_build_env.sh
+++ b/scripts/install_build_env.sh
@@ -3,6 +3,7 @@
 python3 -m pip install empy
 python3 -m pip install pymavlink
 python3 -m pip install dronecan
+python3 -m pip install pyserial
 wget https://downloads.arduino.cc/arduino-cli/arduino-cli_0.26.0_Linux_64bit.tar.gz
 mkdir -p bin
 (cd bin && tar xvzf ../arduino-cli_0.26.0_Linux_64bit.tar.gz)


### PR DESCRIPTION
And update the build dependencies.

For some reason, installing python3 pyserial was good enough for me to get the compile process completed but not enough for the upload part. I needed also python pyserial for that. It could just be my old Ubuntu installation, which has gotten messed up over time so I only added a comment about the latter to the build instructions.

BTW: I have also noticed that `make setup` will fail if you are behind a proxy server (not surprisingly since it is trying to download a bunch of things). What surprised me was that also the pure `make` will occasionally fail (I don't know why that wants to access the internet). This is probably something inside the Arduino tools. I didn't try to start fighting with this but turned off the VPN on my home machine (wouldn't be an option for the machine in the office though).