### PR TITLE
Added Flashing LED Mode and JW Board Placeholder

### DIFF
--- a/RemoteIDModule/Makefile
+++ b/RemoteIDModule/Makefile
@@ -15,7 +15,7 @@ export PATH := $(HOME)/.local/bin:$(PATH)
 
 .PHONY: headers
 
-all: headers esp32s3dev esp32c3dev bluemark-db200 bluemark-db110
+all: headers esp32s3dev esp32c3dev bluemark-db200 bluemark-db110 jw-tbd
 
 esp32s3dev: CHIP=esp32s3
 esp32s3dev: ArduRemoteID-ESP32S3_DEV.bin
@@ -28,6 +28,9 @@ bluemark-db200: ArduRemoteID-BLUEMARK_DB200.bin
 
 bluemark-db110: CHIP=esp32c3
 bluemark-db110: ArduRemoteID-BLUEMARK_DB110.bin
+
+jw-tbd: CHIP=esp32s3
+jw-tbd: ArduRemoteID-JW_TBD.bin
 
 setup:
 	@echo "Installing ESP32 support"

--- a/RemoteIDModule/RemoteIDModule.ino
+++ b/RemoteIDModule/RemoteIDModule.ino
@@ -256,7 +256,7 @@ void set_output_led(uint32_t _now) {
     }
 #else
     // Default LED Behavior
-    digitalWrite(arm_check_ok?!STATUS_LED_ON:STATUS_LED_ON);
+    digitalWrite(PIN_STATUS_LED,arm_check_ok?!STATUS_LED_ON:STATUS_LED_ON);
 #endif // LED_MODE_FLASH
 #endif // PIN_STATUS_LED
 }

--- a/RemoteIDModule/RemoteIDModule.ino
+++ b/RemoteIDModule/RemoteIDModule.ino
@@ -43,6 +43,10 @@ static WebInterface webif;
 #include "soc/soc.h"
 #include "soc/rtc_cntl_reg.h"
 
+static uint32_t last_led_trig_ms;
+static bool arm_check_ok = false; // goes true for LED arm check status
+static bool pfst_check_ok = false; 
+
 /*
   setup serial ports
  */
@@ -88,6 +92,12 @@ void setup()
     // optional CAN termination control
     pinMode(PIN_CAN_TERM, OUTPUT);
     digitalWrite(PIN_CAN_TERM, HIGH);
+#endif
+
+#ifdef PIN_STATUS_LED
+    // LED off if good to arm
+    pfst_check_ok = true;   // note - this will need to be expanded to better capture PFST test status
+    pinMode(PIN_STATUS_LED, OUTPUT);
 #endif
 
     esp_log_level_set("*", ESP_LOG_DEBUG);
@@ -216,11 +226,7 @@ static void set_data(Transport &t)
     }
     t.set_parse_fail(reason);
 
-#ifdef PIN_STATUS_LED
-    // LED off if good to arm
-    pinMode(PIN_STATUS_LED, OUTPUT);
-    digitalWrite(PIN_STATUS_LED, reason==nullptr?!STATUS_LED_ON:STATUS_LED_ON);
-#endif
+    arm_check_ok = (reason==nullptr);
 
     uint32_t now_ms = millis();
     uint32_t location_age_ms = now_ms - t.get_last_location_ms();
@@ -228,6 +234,31 @@ static void set_data(Transport &t)
     if (location_age_ms < last_location_age_ms) {
         last_location_ms = t.get_last_location_ms();
     }
+}
+
+void set_output_led(uint32_t _now) {
+#ifdef PIN_STATUS_LED
+#ifdef LED_MODE_FLASH
+    // LED off if good to arm
+    //pinMode(PIN_STATUS_LED, OUTPUT);
+    
+    if (arm_check_ok && pfst_check_ok) {
+        digitalWrite(PIN_STATUS_LED, STATUS_LED_ON);
+        last_led_trig_ms = 0; 
+    } else if (!arm_check_ok && pfst_check_ok) {
+        if (_now - last_led_trig_ms > 100) {
+            digitalWrite(PIN_STATUS_LED,!digitalRead(PIN_STATUS_LED));
+            last_led_trig_ms = _now;
+        }
+    } else {
+        digitalWrite(PIN_STATUS_LED, STATUS_LED_ON);
+        last_led_trig_ms = 0;
+    }
+#else
+    // Default LED Behavior
+    digitalWrite(arm_check_ok?!STATUS_LED_ON:STATUS_LED_ON);
+#endif // LED_MODE_FLASH
+#endif // PIN_STATUS_LED
 }
 
 static uint8_t loop_counter = 0;
@@ -315,6 +346,9 @@ void loop()
         ble.transmit_legacy_name(UAS_data);
     }
 
+#ifdef PIN_STATUS_LED
+    set_output_led(now_ms);
+#endif 
     // sleep for a bit for power saving
     delay(1);
 }

--- a/RemoteIDModule/board_config.h
+++ b/RemoteIDModule/board_config.h
@@ -47,6 +47,19 @@
 #define PIN_STATUS_LED GPIO_NUM_8 // LED to signal the status
 #define STATUS_LED_ON 1
 
+#elif defined(BOARD_JW_TBD)
+#define BOARD_ID 5
+#define PIN_CAN_TX GPIO_NUM_47
+#define PIN_CAN_RX GPIO_NUM_38
+
+#define PIN_UART_TX 18
+#define PIN_UART_RX 17
+
+#define PIN_STATUS_LED GPIO_NUM_5 // LED to signal the status
+#define LED_MODE_FLASH 1 // flashing LED configuration
+#define STATUS_LED_ON 1
+
+#define CAN_APP_NODE_NAME "JW TBD"
 #else
 #error "unsupported board"
 #endif


### PR DESCRIPTION
- adds LED_MODE_FLASH as an alternative to the default basic LED behavior. 
- adds JW_TBD placeholder for Jeff Wurzbach module board

Note - @tridge  this adds two bools that indicate PFST and ARM Check status. The PFST currently gets set on after the inits() are run on the transmitters, however we'll want to more explicitly set this variable if we can. 