### PR TITLE
SelfID: Make SELF ID messages optional

### DIFF
--- a/RemoteIDModule/DroneCAN.cpp
+++ b/RemoteIDModule/DroneCAN.cpp
@@ -614,6 +614,19 @@ void DroneCAN::handle_param_getset(CanardInstance* ins, CanardRxTransfer* transf
                 }
                 break;
             }
+            case Parameters::ParamType::CHAR23: {
+                if (req.value.union_tag != UAVCAN_PROTOCOL_PARAM_VALUE_STRING_VALUE) {
+                    return;
+                }
+                char v[24] {};
+                strncpy(v, (const char *)&req.value.string_value.data[0], req.value.string_value.len);
+                if (vp->min_len > 0 && strlen(v) < vp->min_len) {
+                    can_printf("%s too short - min %u", vp->name, vp->min_len);
+                } else {
+                    vp->set_char23(v);
+                }
+                break;
+            }
             case Parameters::ParamType::CHAR64: {
                 if (req.value.union_tag != UAVCAN_PROTOCOL_PARAM_VALUE_STRING_VALUE) {
                     return;
@@ -666,6 +679,13 @@ void DroneCAN::handle_param_getset(CanardInstance* ins, CanardRxTransfer* transf
             if (vp->flags & PARAM_FLAG_PASSWORD) {
                 s = "********";
             }
+            strncpy((char*)pkt.value.string_value.data, s, sizeof(pkt.value.string_value.data));
+            pkt.value.string_value.len = strlen(s);
+            break;
+        }
+        case Parameters::ParamType::CHAR23: {
+            pkt.value.union_tag = UAVCAN_PROTOCOL_PARAM_VALUE_STRING_VALUE;
+            const char *s = vp->get_char23();
             strncpy((char*)pkt.value.string_value.data, s, sizeof(pkt.value.string_value.data));
             pkt.value.string_value.len = strlen(s);
             break;

--- a/RemoteIDModule/RemoteIDModule.ino
+++ b/RemoteIDModule/RemoteIDModule.ino
@@ -183,9 +183,19 @@ static void set_data(Transport &t)
     UAS_data.OperatorIDValid = 1;
 
     // SelfID
-    UAS_data.SelfID.DescType = (ODID_desctype_t)self_id.description_type;
-    ODID_COPY_STR(UAS_data.SelfID.Desc, self_id.description);
-    UAS_data.SelfIDValid = 1;
+    if (g.have_self_id_info()) {
+        // from parameters
+        UAS_data.SelfID.DescType = (ODID_desctype_t)g.description_type;
+        ODID_COPY_STR(UAS_data.SelfID.Desc, g.description);
+        UAS_data.SelfIDValid = 1;
+    } else {
+        // from transport
+        if (strlen(self_id.description) > 0) {
+            UAS_data.SelfID.DescType = (ODID_desctype_t)self_id.description_type;
+            ODID_COPY_STR(UAS_data.SelfID.Desc, self_id.description);
+            UAS_data.SelfIDValid = 1;
+        }
+    }
 
     // System
     if (system.timestamp != 0) {

--- a/RemoteIDModule/parameters.h
+++ b/RemoteIDModule/parameters.h
@@ -19,6 +19,10 @@ public:
     uint8_t ua_type;
     uint8_t id_type;
     char uas_id[21] = "ABCD123456789";
+    //
+    uint8_t description_type;
+    char description[24];  // For debug = "Pesticides are sprayed";
+    //
     float wifi_nan_rate;
     float wifi_power;
     float bt4_rate;
@@ -41,6 +45,7 @@ public:
         FLOAT=3,
         CHAR20=4,
         CHAR64=5,
+        CHAR23=6,
     };
 
     struct Param {
@@ -56,11 +61,13 @@ public:
         void set_uint8(uint8_t v) const;
         void set_uint32(uint32_t v) const;
         void set_char20(const char *v) const;
+        void set_char23(const char *v) const;
         void set_char64(const char *v) const;
         uint8_t get_uint8() const;
         uint32_t get_uint32() const;
         float get_float() const;
         const char *get_char20() const;
+        const char *get_char23() const;
         const char *get_char64() const;
         bool get_as_float(float &v) const;
         void set_as_float(float v) const;
@@ -74,6 +81,7 @@ public:
     void init(void);
 
     bool have_basic_id_info(void) const;
+    bool have_self_id_info(void) const;
 
     bool set_by_name_uint8(const char *name, uint8_t v);
     bool set_by_name_char64(const char *name, const char *s);


### PR DESCRIPTION
1. The SELF ID message is an optional specification.
2. the number of characters in the text is also sent out when the number of characters is 0.
I make the SELF ID message optional, in accordance with the F3411-22A specification.
If the number of characters in the text is 0, there is no merit in sending the message.
and one frame length is 25 bytes longer.
I will only send out the message when the text is set.
I will allow SELF ID messages to be set in the configuration parameter.

AFTER: 
TEXT LEN > 0
![Screenshot_20220922-110001360](https://user-images.githubusercontent.com/646194/191647933-376606ce-5461-4e3a-bd5a-95837be18a02.jpg)

TEXT LEN = 0
![Screenshot_20220922-112207449](https://user-images.githubusercontent.com/646194/191647956-210c02a4-efc3-4dd5-b664-0f3a8727f954.jpg)