### PR TITLE
OperatorID: Make OPERATOR ID messages optional

### DIFF
--- a/RemoteIDModule/RemoteIDModule.ino
+++ b/RemoteIDModule/RemoteIDModule.ino
@@ -178,9 +178,19 @@ static void set_data(Transport &t)
     UAS_data.BasicIDValid[0] = 1;
 
     // OperatorID
-    UAS_data.OperatorID.OperatorIdType = (ODID_operatorIdType_t)operator_id.operator_id_type;
-    ODID_COPY_STR(UAS_data.OperatorID.OperatorId, operator_id.operator_id);
-    UAS_data.OperatorIDValid = 1;
+    if (g.have_operator_id_info()) {
+        // from parameters
+        UAS_data.OperatorID.OperatorIdType = (ODID_operatorIdType_t)g.operator_id_type;
+        ODID_COPY_STR(UAS_data.OperatorID.OperatorId, g.operator_id);
+        UAS_data.OperatorIDValid = 1;
+    } else {
+        // from transport
+        if (strlen(operator_id.operator_id) > 0) {
+            UAS_data.OperatorID.OperatorIdType = (ODID_operatorIdType_t)operator_id.operator_id_type;
+            ODID_COPY_STR(UAS_data.OperatorID.OperatorId, operator_id.operator_id);
+            UAS_data.OperatorIDValid = 1;
+        }
+    }
 
     // SelfID
     UAS_data.SelfID.DescType = (ODID_desctype_t)self_id.description_type;

--- a/RemoteIDModule/parameters.cpp
+++ b/RemoteIDModule/parameters.cpp
@@ -15,6 +15,8 @@ const Parameters::Param Parameters::params[] = {
     { "UAS_TYPE",          Parameters::ParamType::UINT8,  (const void*)&g.ua_type,          0, 0, 15 },
     { "UAS_ID_TYPE",       Parameters::ParamType::UINT8,  (const void*)&g.id_type,          0, 0, 4 },
     { "UAS_ID",            Parameters::ParamType::CHAR20, (const void*)&g.uas_id[0],        0, 0, 0 },
+    { "OPERATOR_ID_TYPE",  Parameters::ParamType::UINT8,  (const void*)&g.operator_id_type, 0, 0, 255 },
+    { "OPERATOR_ID",       Parameters::ParamType::CHAR20, (const void*)&g.operator_id[0],   0, 0, 0 },
     { "BAUDRATE",          Parameters::ParamType::UINT32, (const void*)&g.baudrate,         57600, 9600, 921600 },
     { "WIFI_NAN_RATE",     Parameters::ParamType::FLOAT,  (const void*)&g.wifi_nan_rate,    0, 0, 5 },
     { "WIFI_POWER",        Parameters::ParamType::FLOAT,  (const void*)&g.wifi_power,       20, 2, 20 },
@@ -327,6 +329,17 @@ void Parameters::init(void)
 bool Parameters::have_basic_id_info(void) const
 {
     return strlen(g.uas_id) > 0 && g.id_type > 0 && g.ua_type > 0;
+}
+
+/**
+ * check if OperatorID info is filled in with parameters 
+ * 
+ * @retval true  Has OPERATOR ID information.
+ * @retval false Does not have OPERATOR ID information.
+ */
+bool Parameters::have_operator_id_info(void) const
+{
+    return strlen(g.operator_id) > 0;
 }
 
 bool Parameters::set_by_name_uint8(const char *name, uint8_t v)

--- a/RemoteIDModule/parameters.h
+++ b/RemoteIDModule/parameters.h
@@ -19,6 +19,10 @@ public:
     uint8_t ua_type;
     uint8_t id_type;
     char uas_id[21] = "ABCD123456789";
+    //
+    uint8_t operator_id_type;
+    char operator_id[21];  // For debug = "ABC1234567890";
+    //
     float wifi_nan_rate;
     float wifi_power;
     float bt4_rate;
@@ -74,6 +78,7 @@ public:
     void init(void);
 
     bool have_basic_id_info(void) const;
+    bool have_operator_id_info(void) const;
 
     bool set_by_name_uint8(const char *name, uint8_t v);
     bool set_by_name_char64(const char *name, const char *s);


### PR DESCRIPTION
The Operator ID message is optional.
1. if the number of text characters is 0, the message is not sent.
2. Operator ID information can be set in the configuration parameter.

TEXT LEN > 0
![Screenshot_20220922-150811868](https://user-images.githubusercontent.com/646194/191675642-dadbd9e6-bb21-45d7-b1c9-09314f8962fd.jpg)

TEXT LEN < 1
![Screenshot_20220922-151853446](https://user-images.githubusercontent.com/646194/191675605-1a07d2d5-0186-4adc-a463-f6e29c080240.jpg)
