### PR TITLE
scripts: Bring arduino-cli version up to date

### DIFF
--- a/scripts/install_build_env.sh
+++ b/scripts/install_build_env.sh
@@ -4,6 +4,6 @@ python3 -m pip install empy
 python3 -m pip install pymavlink
 python3 -m pip install dronecan
 python3 -m pip install pyserial
-wget https://downloads.arduino.cc/arduino-cli/arduino-cli_0.26.0_Linux_64bit.tar.gz
+wget https://downloads.arduino.cc/arduino-cli/arduino-cli_0.27.1_Linux_64bit.tar.gz
 mkdir -p bin
-(cd bin && tar xvzf ../arduino-cli_0.26.0_Linux_64bit.tar.gz)
+(cd bin && tar xvzf ../arduino-cli_0.27.1_Linux_64bit.tar.gz)


### PR DESCRIPTION
I ran "make boards" and got the following message.
I change the version of arduino-cli from 0.26.0 to 0.27.1.

messages:
A new release of Arduino CLI is available: 0.26.0 → 0.27.1
https://arduino.github.io/arduino-cli/latest/installation/#latest-packages
