### PR TITLE
bugfix BLE legacy advertisements broken

### DIFF
--- a/RemoteIDModule/BLE_TX.h
+++ b/RemoteIDModule/BLE_TX.h
@@ -9,7 +9,6 @@ class BLE_TX : public Transmitter {
 public:
     bool init(void) override;
     bool transmit_longrange(ODID_UAS_Data &UAS_data);
-    bool transmit_legacy_name(ODID_UAS_Data &UAS_data);
     bool transmit_legacy(ODID_UAS_Data &UAS_data);
 
 private:

--- a/RemoteIDModule/RemoteIDModule.ino
+++ b/RemoteIDModule/RemoteIDModule.ino
@@ -381,7 +381,6 @@ void loop()
         now_ms - last_update_bt4_ms > 200/g.bt4_rate) {
         last_update_bt4_ms = now_ms;
         ble.transmit_legacy(UAS_data);
-        ble.transmit_legacy_name(UAS_data);
     }
 
     // sleep for a bit for power saving


### PR DESCRIPTION
In the current implementation, BLE4 legacy transmission work for about 30 seconds. Then it crashes and no BT4 legacy packets can be received anymore. 

The "issue" seems to be caused the separate BLE legacy advertisement service for the BLE device name. This was also solved in this PR https://github.com/ArduPilot/ArduRemoteID/pull/26 but due to parallel code development at that time, this part wasn't included. The solution is to incorporate the BLE device name broadcast into the regular BT4 transmissions. Not sure what the underlying issue is, perhaps it is just a bug in the ESP/Arduino environment.