### PR TITLE
Override pre-arm checks

### DIFF
--- a/RemoteIDModule/RemoteIDModule.ino
+++ b/RemoteIDModule/RemoteIDModule.ino
@@ -283,6 +283,11 @@ static void set_data(Transport &t)
     t.set_parse_fail(reason);
 
     arm_check_ok = (reason==nullptr);
+
+    if (g.options & OPTIONS_FORCE_ARM_OK) {
+        arm_check_ok = true;
+    }
+
     led.set_state(pfst_check_ok && arm_check_ok? Led::LedState::ARM_OK : Led::LedState::ARM_FAIL);
 
     uint32_t now_ms = millis();

--- a/RemoteIDModule/parameters.cpp
+++ b/RemoteIDModule/parameters.cpp
@@ -37,6 +37,7 @@ const Parameters::Param Parameters::params[] = {
     { "PUBLIC_KEY4",       Parameters::ParamType::CHAR64, (const void*)&g.public_keys[3], },
     { "PUBLIC_KEY5",       Parameters::ParamType::CHAR64, (const void*)&g.public_keys[4], },
     { "MAVLINK_SYSID",     Parameters::ParamType::UINT8,  (const void*)&g.mavlink_sysid,    0, 0, 254 },
+    { "OPTIONS",           Parameters::ParamType::UINT8,  (const void*)&g.options,          0, 0, 254 },
     { "DONE_INIT",         Parameters::ParamType::UINT8,  (const void*)&g.done_init,        0, 0, 0, PARAM_FLAG_HIDDEN},
     { "",                  Parameters::ParamType::NONE,   nullptr,  },
 };

--- a/RemoteIDModule/parameters.h
+++ b/RemoteIDModule/parameters.h
@@ -35,6 +35,7 @@ public:
     char wifi_ssid[21] = "";
     char wifi_password[21] = "ArduRemoteID";
     uint8_t wifi_channel = 6;
+    uint8_t options;
     struct {
         char b64_key[64];
     } public_keys[MAX_PUBLIC_KEYS];
@@ -99,5 +100,8 @@ public:
 private:
     void load_defaults(void);
 };
+
+// bits for OPTIONS parameter
+#define OPTIONS_FORCE_ARM_OK 1U<<0
 
 extern Parameters g;

--- a/RemoteIDModule/transport.cpp
+++ b/RemoteIDModule/transport.cpp
@@ -39,6 +39,12 @@ uint8_t Transport::arm_status_check(const char *&reason)
 
     uint8_t status = MAV_ODID_PRE_ARM_FAIL_GENERIC;
 
+    //return status OK if we have enabled the force arm option
+    if (g.options & OPTIONS_FORCE_ARM_OK) {
+        status = MAV_ODID_GOOD_TO_ARM;
+        return status;
+    }
+
     if (last_location_ms == 0 || now_ms - last_location_ms > max_age_location_ms) {
         reason = "missing location message";
     } else if (!g.have_basic_id_info() && (last_basic_id_ms == 0 || now_ms - last_basic_id_ms > max_age_other_ms)) {


### PR DESCRIPTION
Added a define in option.h to disable all pre-arm checks (OVERRIDE_ARM_STATUS). Default disabled, it is useful for development purposes.

