### PR TITLE
RemoteIDModule: Added Operator-ID and Self-ID

### DIFF
--- a/RemoteIDModule/RemoteIDModule.ino
+++ b/RemoteIDModule/RemoteIDModule.ino
@@ -226,14 +226,34 @@ static void set_data(Transport &t)
     }
 
     // OperatorID
-    UAS_data.OperatorID.OperatorIdType = (ODID_operatorIdType_t)operator_id.operator_id_type;
-    ODID_COPY_STR(UAS_data.OperatorID.OperatorId, operator_id.operator_id);
-    UAS_data.OperatorIDValid = 1;
+    if (g.have_operator_id_info()) {
+        // from parameters
+        UAS_data.OperatorID.OperatorIdType = (ODID_operatorIdType_t)g.operator_id_type;
+        ODID_COPY_STR(UAS_data.OperatorID.OperatorId, g.operator_id);
+        UAS_data.OperatorIDValid = 1;
+    } else {
+        // from transport
+        if (strlen(operator_id.operator_id) > 0) {
+            UAS_data.OperatorID.OperatorIdType = (ODID_operatorIdType_t)operator_id.operator_id_type;
+            ODID_COPY_STR(UAS_data.OperatorID.OperatorId, operator_id.operator_id);
+            UAS_data.OperatorIDValid = 1;
+        }
+    }
 
     // SelfID
-    UAS_data.SelfID.DescType = (ODID_desctype_t)self_id.description_type;
-    ODID_COPY_STR(UAS_data.SelfID.Desc, self_id.description);
-    UAS_data.SelfIDValid = 1;
+    if (g.have_self_id_info()) {
+        // from parameters
+        UAS_data.SelfID.DescType = (ODID_desctype_t)g.description_type;
+        ODID_COPY_STR(UAS_data.SelfID.Desc, g.description);
+        UAS_data.SelfIDValid = 1;
+    } else {
+        // from transport
+        if (strlen(self_id.description) > 0) {
+            UAS_data.SelfID.DescType = (ODID_desctype_t)self_id.description_type;
+            ODID_COPY_STR(UAS_data.SelfID.Desc, self_id.description);
+            UAS_data.SelfIDValid = 1;
+        }
+    }
 
     // System
     if (system.timestamp != 0) {

--- a/RemoteIDModule/parameters.cpp
+++ b/RemoteIDModule/parameters.cpp
@@ -15,9 +15,13 @@ const Parameters::Param Parameters::params[] = {
     { "UAS_TYPE",          Parameters::ParamType::UINT8,  (const void*)&g.ua_type,          0, 0, 15 },
     { "UAS_ID_TYPE",       Parameters::ParamType::UINT8,  (const void*)&g.id_type,          0, 0, 4 },
     { "UAS_ID",            Parameters::ParamType::CHAR20, (const void*)&g.uas_id[0],        0, 0, 0 },
-    { "UAS_TYPE_2",        Parameters::ParamType::UINT8,  (const void*)&g.ua_type_2,          0, 0, 15 },
-    { "UAS_ID_TYPE_2",     Parameters::ParamType::UINT8,  (const void*)&g.id_type_2,          0, 0, 4 },
-    { "UAS_ID_2",          Parameters::ParamType::CHAR20, (const void*)&g.uas_id_2[0],        0, 0, 0 },
+    { "UAS_TYPE_2",        Parameters::ParamType::UINT8,  (const void*)&g.ua_type_2,        0, 0, 15 },
+    { "UAS_ID_TYPE_2",     Parameters::ParamType::UINT8,  (const void*)&g.id_type_2,        0, 0, 4 },
+    { "UAS_ID_2",          Parameters::ParamType::CHAR20, (const void*)&g.uas_id_2[0],      0, 0, 0 },
+    { "DESCRIPTION_TYPE",  Parameters::ParamType::UINT8,  (const void*)&g.description_type, 0, 0, 255 },
+    { "DESCRIPTION",       Parameters::ParamType::CHAR23, (const void*)&g.description[0],   0, 0, 0 },
+    { "OPERATOR_ID_TYPE",  Parameters::ParamType::UINT8,  (const void*)&g.operator_id_type, 0, 0, 255 },
+    { "OPERATOR_ID",       Parameters::ParamType::CHAR20, (const void*)&g.operator_id[0],   0, 0, 0 },
     { "BAUDRATE",          Parameters::ParamType::UINT32, (const void*)&g.baudrate,         57600, 9600, 921600 },
     { "WIFI_NAN_RATE",     Parameters::ParamType::FLOAT,  (const void*)&g.wifi_nan_rate,    0, 0, 5 },
     { "WIFI_BCN_RATE",     Parameters::ParamType::FLOAT,  (const void*)&g.wifi_beacon_rate,    0, 0, 5 },
@@ -171,6 +175,16 @@ void Parameters::Param::set_char20(const char *v) const
     nvs_set_str(handle, name, v);
 }
 
+void Parameters::Param::set_char23(const char *v) const
+{
+    if (min_len > 0 && strlen(v) < min_len) {
+        return;
+    }
+    memset((void*)ptr, 0, 24);
+    strncpy((char *)ptr, v, 23);
+    nvs_set_str(handle, name, v);
+}
+
 void Parameters::Param::set_char64(const char *v) const
 {
     if (min_len > 0 && strlen(v) < min_len) {
@@ -200,6 +214,12 @@ float Parameters::Param::get_float() const
 }
 
 const char *Parameters::Param::get_char20() const
+{
+    const char *p = (const char *)ptr;
+    return p;
+}
+
+const char *Parameters::Param::get_char23() const
 {
     const char *p = (const char *)ptr;
     return p;
@@ -296,6 +316,11 @@ void Parameters::init(void)
             nvs_get_str(handle, p.name, (char *)p.ptr, &len);
             break;
         }
+        case ParamType::CHAR23: {
+            size_t len = 24;
+            nvs_get_str(handle, p.name, (char *)p.ptr, &len);
+            break;
+        }
         case ParamType::CHAR64: {
             size_t len = 65;
             nvs_get_str(handle, p.name, (char *)p.ptr, &len);
@@ -339,6 +364,28 @@ bool Parameters::have_basic_id_2_info(void) const
     return strlen(g.uas_id_2) > 0 && g.id_type_2 > 0 && g.ua_type_2 > 0;
 }
 
+/**
+ * check if OperatorID info is filled in with parameters 
+ * 
+ * @retval true  Has OPERATOR ID information.
+ * @retval false Does not have OPERATOR ID information.
+ */
+bool Parameters::have_operator_id_info(void) const
+{
+    return strlen(g.operator_id) > 0;
+}
+
+/**
+ * check if SelfID info is filled in with parameters 
+ * 
+ * @retval true  Has SELF ID information.
+ * @retval false Does not have SELF ID information.
+ */
+bool Parameters::have_self_id_info(void) const
+{
+    return strlen(g.description) > 0;
+}
+
 bool Parameters::set_by_name_uint8(const char *name, uint8_t v)
 {
     const auto *f = find(name);
@@ -377,6 +424,9 @@ bool Parameters::set_by_name_string(const char *name, const char *s)
             return true;
         case ParamType::CHAR20:
             f->set_char20(s);
+            return true;
+        case ParamType::CHAR23:
+            f->set_char23(s);
             return true;
         case ParamType::CHAR64:
             f->set_char64(s);

--- a/RemoteIDModule/parameters.h
+++ b/RemoteIDModule/parameters.h
@@ -22,6 +22,10 @@ public:
     uint8_t ua_type_2;
     uint8_t id_type_2;
     char uas_id_2[21] = "ABCD123456789";
+    uint8_t description_type;
+    char description[24];
+    uint8_t operator_id_type;
+    char operator_id[21];
     float wifi_nan_rate;
     float wifi_beacon_rate;
     float wifi_power;
@@ -46,6 +50,7 @@ public:
         FLOAT=3,
         CHAR20=4,
         CHAR64=5,
+        CHAR23=6,
     };
 
     struct Param {
@@ -61,11 +66,13 @@ public:
         void set_uint8(uint8_t v) const;
         void set_uint32(uint32_t v) const;
         void set_char20(const char *v) const;
+        void set_char23(const char *v) const;
         void set_char64(const char *v) const;
         uint8_t get_uint8() const;
         uint32_t get_uint32() const;
         float get_float() const;
         const char *get_char20() const;
+        const char *get_char23() const;
         const char *get_char64() const;
         bool get_as_float(float &v) const;
         void set_as_float(float v) const;
@@ -80,6 +87,8 @@ public:
 
     bool have_basic_id_info(void) const;
     bool have_basic_id_2_info(void) const;
+    bool have_operator_id_info(void) const;
+    bool have_self_id_info(void) const;
 
     bool set_by_name_uint8(const char *name, uint8_t v);
     bool set_by_name_char64(const char *name, const char *s);


### PR DESCRIPTION
I would allow the operator ID and self ID in the option message to be set by parameters.

AFTER
![Screenshot_20221016-140241548](https://user-images.githubusercontent.com/646194/196019570-141ff862-f574-400d-9888-5f1a8e6a79d2.jpg)