### PR TITLE
fix: Install `pexpect` to fix failing `regen_headers.sh`

### DIFF
--- a/scripts/install_build_env.sh
+++ b/scripts/install_build_env.sh
@@ -4,6 +4,7 @@ python3 -m pip install empy
 python3 -m pip install pymavlink
 python3 -m pip install dronecan
 python3 -m pip install pyserial
+python3 -m pip install pexpect
 wget https://downloads.arduino.cc/arduino-cli/arduino-cli_0.27.1_Linux_64bit.tar.gz
 mkdir -p bin
 (cd bin && tar xvzf ../arduino-cli_0.27.1_Linux_64bit.tar.gz)


### PR DESCRIPTION
While following the linux build directions in `BUILD.md`, the script `scripts/regen_headers.sh` fails to generate DroneCAN headers due to a missing python module:
```
Generating DroneCAN headers for libcanard
Traceback (most recent call last):
  File "/flash/arduremoteid/modules/dronecan_dsdlc/dronecan_dsdlc.py", line 20, in <module>
    from dronecan_dsdlc_tester import *
  File "/flash/arduremoteid/modules/dronecan_dsdlc/dronecan_dsdlc_tester.py", line 12, in <module>
    import pexpect
ModuleNotFoundError: No module named 'pexpect'
./scripts/regen_headers.sh: line 16: cd: libraries/DroneCAN_generated: No such file or directory
./scripts/regen_headers.sh: line 16: cd: libraries/DroneCAN_generated: No such file or directory
./scripts/regen_headers.sh: line 16: cd: libraries/DroneCAN_generated: No such file or directory
./scripts/regen_headers.sh: line 16: cd: libraries/DroneCAN_generated: No such file or directory
./scripts/regen_headers.sh: line 16: cd: libraries/DroneCAN_generated: No such file or directory
./scripts/regen_headers.sh: line 16: cd: libraries/DroneCAN_generated: No such file or directory
./scripts/regen_headers.sh: line 16: cd: libraries/DroneCAN_generated: No such file or directory
./scripts/regen_headers.sh: line 16: cd: libraries/DroneCAN_generated: No such file or directory
./scripts/regen_headers.sh: line 16: cd: libraries/DroneCAN_generated: No such file or directory
```

This issue is resolved (and build completed successfully) following a `pip install pexpect`.