### PR TITLE
Provide a pop up if the OTA upgrade fails

### DIFF
--- a/RemoteIDModule/check_firmware.h
+++ b/RemoteIDModule/check_firmware.h
@@ -17,7 +17,7 @@ public:
     } app_descriptor_t;
 
     // check the firmware on the partition which will be updated by OTA
-    static bool check_OTA_next(const uint8_t *lead_bytes, uint32_t lead_length);
+    static bool check_OTA_next(const esp_partition_t *part, const uint8_t *lead_bytes, uint32_t lead_length);
     static bool check_OTA_running(void);
 
 private:

--- a/RemoteIDModule/web/index.html
+++ b/RemoteIDModule/web/index.html
@@ -121,16 +121,18 @@
                 var xhr = new window.XMLHttpRequest();
                 xhr.upload.addEventListener('progress', function(evt) {
                     if (evt.lengthComputable) {
-                        var per = evt.loaded / evt.total;
-                        $('#progress').html('progress: ' + Math.round(per*100) + '%');
-                        if (evt.loaded == evt.total) {
-                            setTimeout(function(){ //popup after 1 second
-                                $('#progress').html('progress: done');
-                                alert("Firmware upgrade completed!\n\nPress OK to reboot the RemoteID device.");
-                                window.location.reload(1);
-                            }, 1000);
-                        }
-                    }
+                       var per = evt.loaded / evt.total;
+                       $('#progress').html('progress: ' + Math.round(per*100) + '%');
+                       if (evt.loaded == evt.total) {
+                           setTimeout(function(){ //popup after 2 second
+							   if (xhr.status === 200) {
+                                   $('#progress').html('progress: done');
+                                   alert("Firmware upgrade completed!\n\nPress OK to reboot the RemoteID device.");
+                                   window.location.reload(true);
+							   }
+                           }, 2000);
+                       }
+                   }
                 }, false);
                 return xhr;
             },
@@ -138,6 +140,11 @@
                 console.log('success!');
             },
             error: function (a, b, c) {
+				 setTimeout(function(){ //popup after 1 second
+                     $('#progress').html('progress: error');
+                     alert("Firmware upgrade FAILED!\n\nPlease check that:\na) you downloaded the OTA firmware (ending on _OTA.bin)\nb) you downloaded the correct file for your board\nc) if the LOCK_LEVEL has been set to 2 in your board, make sure you uploaded firmware that is signed with the correct key.");
+                     window.location.reload(true);
+                 }, 100);
             }
         });
     });


### PR DESCRIPTION
In this PR, a pop up is shown if the OTA upgrade via the web interface fails. 
For instance if the wrong file is uploaded. 


![fail](https://user-images.githubusercontent.com/105798731/201529537-d3640d48-0e7a-4e65-abd9-ceb43d8a0368.png)
