### PR TITLE
init UAS payload in set_data

### DIFF
--- a/RemoteIDModule/RemoteIDModule.ino
+++ b/RemoteIDModule/RemoteIDModule.ino
@@ -171,6 +171,8 @@ static void set_data(Transport &t)
     const auto &self_id = t.get_self_id();
     const auto &location = t.get_location();
 
+    odid_initUasData(&UAS_data);
+
     /*
       if we don't have BasicID info from parameters and we have it
       from the DroneCAN or MAVLink transport then copy it to the


### PR DESCRIPTION
In the current implementation, the UAS data variable that contains the RID payload is only initialized during boot. Also when a "valid" var like SelfIDValid is set to 1, it will remain 1 until the RID module reboots.

In the PR, the UAS data variable is initialized before filling it.

So if a packet payload has no valid data anymore (like location, system, selfID etc), do not broadcast it anymore. Otherwise the old, outdated, data would be used, as in the current implementation.