### PR TITLE
parameter reset to defaults

### DIFF
--- a/RemoteIDModule/parameters.cpp
+++ b/RemoteIDModule/parameters.cpp
@@ -144,7 +144,8 @@ void Parameters::Param::set_uint8(uint8_t v) const
     nvs_set_u8(handle, name, *p);
     if (strcmp(name, "TO_DEFAULTS") == 0) {
         if (v == 1) {
-            esp_restart(); //reset, so the init function will set it to factory defaults
+            nvs_flash_erase();
+            esp_restart();
         }
     }
 }
@@ -319,10 +320,11 @@ void Parameters::init(void)
 
     }
     if (g.to_factory_defaults == 1) {
-        reset_to_defaults(); //save to NVS
-        load_defaults();
-        set_by_name_uint8("TO_DEFAULTS", 0);
+        //should not happen, but in case the parameter is still set to 1, erase flash and reboot
+        nvs_flash_erase();
+        esp_restart();
     }
+
     if (g.done_init == 0) {
         set_by_name_uint8("DONE_INIT", 1);
         // setup public keys

--- a/RemoteIDModule/parameters.cpp
+++ b/RemoteIDModule/parameters.cpp
@@ -38,6 +38,7 @@ const Parameters::Param Parameters::params[] = {
     { "PUBLIC_KEY5",       Parameters::ParamType::CHAR64, (const void*)&g.public_keys[4], },
     { "MAVLINK_SYSID",     Parameters::ParamType::UINT8,  (const void*)&g.mavlink_sysid,    0, 0, 254 },
     { "OPTIONS",           Parameters::ParamType::UINT8,  (const void*)&g.options,          0, 0, 254 },
+    { "TO_DEFAULTS",     Parameters::ParamType::UINT8,  (const void*)&g.to_factory_defaults,    0, 0, 1 }, //if set to 1, reset to factory defaults and make 0.
     { "DONE_INIT",         Parameters::ParamType::UINT8,  (const void*)&g.done_init,        0, 0, 0, PARAM_FLAG_HIDDEN},
     { "",                  Parameters::ParamType::NONE,   nullptr,  },
 };
@@ -272,6 +273,34 @@ void Parameters::load_defaults(void)
     }
 }
 
+/*
+  set to factory defaults from parameter table
+ */
+void Parameters::reset_to_defaults(void)
+{
+    for (const auto &p : params) {
+        switch (p.ptype) {
+        case ParamType::UINT8:
+            p.set_uint32(uint8_t(p.default_value));
+            break;
+        case ParamType::UINT32:
+            p.set_uint32(uint32_t(p.default_value));
+            break;
+        case ParamType::FLOAT:
+            p.set_float(float(p.default_value));
+            break;
+        case ParamType::CHAR20: {
+            p.set_char20("");
+            break;
+        }
+        case ParamType::CHAR64: {
+            p.set_char64("");
+            break;
+        }
+        }
+    }
+}
+
 void Parameters::init(void)
 {
     load_defaults();
@@ -312,7 +341,11 @@ void Parameters::init(void)
                  mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
 
     }
-
+    if (g.to_factory_defaults == 1) {
+        reset_to_defaults(); //save to NVS
+        load_defaults();
+        set_by_name_uint8("to_factory_defaults", 0);
+    }
     if (g.done_init == 0) {
         set_by_name_uint8("DONE_INIT", 1);
         // setup public keys

--- a/RemoteIDModule/parameters.cpp
+++ b/RemoteIDModule/parameters.cpp
@@ -142,6 +142,11 @@ void Parameters::Param::set_uint8(uint8_t v) const
     auto *p = (uint8_t *)ptr;
     *p = v;
     nvs_set_u8(handle, name, *p);
+    if (strcmp(name, "TO_DEFAULTS") == 0) {
+        if (v == 1) {
+            esp_restart(); //reset, so the init function will set it to factory defaults
+        }
+    }
 }
 
 void Parameters::Param::set_uint32(uint32_t v) const
@@ -273,34 +278,6 @@ void Parameters::load_defaults(void)
     }
 }
 
-/*
-  set to factory defaults from parameter table
- */
-void Parameters::reset_to_defaults(void)
-{
-    for (const auto &p : params) {
-        switch (p.ptype) {
-        case ParamType::UINT8:
-            p.set_uint32(uint8_t(p.default_value));
-            break;
-        case ParamType::UINT32:
-            p.set_uint32(uint32_t(p.default_value));
-            break;
-        case ParamType::FLOAT:
-            p.set_float(float(p.default_value));
-            break;
-        case ParamType::CHAR20: {
-            p.set_char20("");
-            break;
-        }
-        case ParamType::CHAR64: {
-            p.set_char64("");
-            break;
-        }
-        }
-    }
-}
-
 void Parameters::init(void)
 {
     load_defaults();
@@ -344,7 +321,7 @@ void Parameters::init(void)
     if (g.to_factory_defaults == 1) {
         reset_to_defaults(); //save to NVS
         load_defaults();
-        set_by_name_uint8("to_factory_defaults", 0);
+        set_by_name_uint8("TO_DEFAULTS", 0);
     }
     if (g.done_init == 0) {
         set_by_name_uint8("DONE_INIT", 1);

--- a/RemoteIDModule/parameters.h
+++ b/RemoteIDModule/parameters.h
@@ -35,15 +35,8 @@ public:
     char wifi_ssid[21] = "";
     char wifi_password[21] = "ArduRemoteID";
     uint8_t wifi_channel = 6;
-<<<<<<< HEAD
-    uint8_t options;
-=======
-<<<<<<< HEAD
->>>>>>> 727a68a (added OPTIONS parameter)
     uint8_t to_factory_defaults = 0;
-=======
     uint8_t options;
->>>>>>> 9a24a3e (added OPTIONS parameter)
     struct {
         char b64_key[64];
     } public_keys[MAX_PUBLIC_KEYS];

--- a/RemoteIDModule/parameters.h
+++ b/RemoteIDModule/parameters.h
@@ -35,8 +35,15 @@ public:
     char wifi_ssid[21] = "";
     char wifi_password[21] = "ArduRemoteID";
     uint8_t wifi_channel = 6;
+<<<<<<< HEAD
     uint8_t options;
+=======
+<<<<<<< HEAD
+>>>>>>> 727a68a (added OPTIONS parameter)
     uint8_t to_factory_defaults = 0;
+=======
+    uint8_t options;
+>>>>>>> 9a24a3e (added OPTIONS parameter)
     struct {
         char b64_key[64];
     } public_keys[MAX_PUBLIC_KEYS];

--- a/RemoteIDModule/parameters.h
+++ b/RemoteIDModule/parameters.h
@@ -100,7 +100,6 @@ public:
 
 private:
     void load_defaults(void);
-    void reset_to_defaults(void);
 };
 
 // bits for OPTIONS parameter

--- a/RemoteIDModule/parameters.h
+++ b/RemoteIDModule/parameters.h
@@ -36,6 +36,7 @@ public:
     char wifi_password[21] = "ArduRemoteID";
     uint8_t wifi_channel = 6;
     uint8_t options;
+    uint8_t to_factory_defaults = 0;
     struct {
         char b64_key[64];
     } public_keys[MAX_PUBLIC_KEYS];
@@ -99,6 +100,7 @@ public:
 
 private:
     void load_defaults(void);
+    void reset_to_defaults(void);
 };
 
 // bits for OPTIONS parameter


### PR DESCRIPTION
This PR adds the parameter TO_DEFAULTS. If set to 1, it will reset all values to their default value. And will also set the TO_DEFAULTS parameter to 0 again. 

This is useful for ArduRemoteID devices that don't have a droneCAN interface. These devices don't have the option to configure string parameters. Of course, a user could flash the firmware via a serial interface; this parameter is a better way without reflashing firmware.