### PR TITLE
Bugfixes upstream

### DIFF
--- a/RemoteIDModule/BLE_TX.cpp
+++ b/RemoteIDModule/BLE_TX.cpp
@@ -169,6 +169,7 @@ bool BLE_TX::transmit_legacy(ODID_UAS_Data &UAS_data)
     // combine header with payload
     memset(legacy_payload, 0, sizeof(legacy_payload));
     memcpy(legacy_payload, header, sizeof(header));
+    legacy_length = sizeof(header);
 
     switch (legacy_phase)
     {

--- a/RemoteIDModule/Makefile
+++ b/RemoteIDModule/Makefile
@@ -73,11 +73,11 @@ checkdev:
 
 upload-%: checkdev
 	@echo "Flashing ArduRemoteID-$*.bin"
-	$(ESPTOOL) --port $(SERDEV) write_flash 0x0 ArduRemoteID-$*.bin
+	@python3 $(ESPTOOL) --port $(SERDEV) write_flash 0x0 ArduRemoteID-$*.bin
 
 uploadota-%: checkdev
 	@echo "Flashing ArduRemoteID-$*_OTA.bin"
-	$(ESPTOOL) --port $(SERDEV) write_flash 0x10000 ArduRemoteID_$*_OTA.bin
+	@python3 $(ESPTOOL) --port $(SERDEV) write_flash 0x10000 ArduRemoteID_$*_OTA.bin
 
 upload: upload-ESP32S3_DEV
 

--- a/RemoteIDModule/RemoteIDModule.ino
+++ b/RemoteIDModule/RemoteIDModule.ino
@@ -393,8 +393,9 @@ void loop()
     }
 
     static uint32_t last_update_bt4_ms;
+    int bt4_states = UAS_data.BasicIDValid[1] ? 7 : 6;
     if (g.bt4_rate > 0 &&
-        now_ms - last_update_bt4_ms > 200/g.bt4_rate) {
+        now_ms - last_update_bt4_ms > (1000.0f/(bt4_states - 1))/g.bt4_rate) {
         last_update_bt4_ms = now_ms;
         ble.transmit_legacy(UAS_data);
     }


### PR DESCRIPTION
Minor bugfixes:

- do not require both python 2 and python 3 to upload the firmware. On my pc without calling python3 explicitly, python 2 was assumed in some places.
- Depending on whether Basic ID 2 was enabled, transmission rate for BT4 was wrong in some cases.
- For BT4, header length was not set initially so the advertiser was crashing when no messages were received, due to length being 0.