### PR TITLE
allow lock_level to set to -1

### DIFF
--- a/RemoteIDModule/DroneCAN.cpp
+++ b/RemoteIDModule/DroneCAN.cpp
@@ -602,6 +602,12 @@ void DroneCAN::handle_param_getset(CanardInstance* ins, CanardRxTransfer* transf
                 }
                 vp->set_uint8(uint8_t(req.value.integer_value));
                 break;
+            case Parameters::ParamType::INT8:
+                if (req.value.union_tag != UAVCAN_PROTOCOL_PARAM_VALUE_INTEGER_VALUE) {
+                    return;
+                }
+                vp->set_int8(int8_t(req.value.integer_value));
+                break;
             case Parameters::ParamType::UINT32:
                 if (req.value.union_tag != UAVCAN_PROTOCOL_PARAM_VALUE_INTEGER_VALUE) {
                     return;
@@ -652,6 +658,16 @@ void DroneCAN::handle_param_getset(CanardInstance* ins, CanardRxTransfer* transf
             pkt.min_value.integer_value = uint8_t(vp->min_value);
             pkt.max_value.union_tag = UAVCAN_PROTOCOL_PARAM_NUMERICVALUE_INTEGER_VALUE;
             pkt.max_value.integer_value = uint8_t(vp->max_value);
+            break;
+        case Parameters::ParamType::INT8:
+            pkt.value.union_tag = UAVCAN_PROTOCOL_PARAM_VALUE_INTEGER_VALUE;
+            pkt.value.integer_value = vp->get_int8();
+            pkt.default_value.union_tag = UAVCAN_PROTOCOL_PARAM_VALUE_INTEGER_VALUE;
+            pkt.default_value.integer_value = int8_t(vp->default_value);
+            pkt.min_value.union_tag = UAVCAN_PROTOCOL_PARAM_NUMERICVALUE_INTEGER_VALUE;
+            pkt.min_value.integer_value = int8_t(vp->min_value);
+            pkt.max_value.union_tag = UAVCAN_PROTOCOL_PARAM_NUMERICVALUE_INTEGER_VALUE;
+            pkt.max_value.integer_value = int8_t(vp->max_value);
             break;
         case Parameters::ParamType::UINT32:
             pkt.value.union_tag = UAVCAN_PROTOCOL_PARAM_VALUE_INTEGER_VALUE;

--- a/RemoteIDModule/parameters.h
+++ b/RemoteIDModule/parameters.h
@@ -12,7 +12,7 @@
 
 class Parameters {
 public:
-    uint8_t lock_level;
+    int8_t lock_level;
     uint8_t can_node;
     uint8_t bcast_powerup;
     uint32_t baudrate = 57600;
@@ -47,6 +47,7 @@ public:
         FLOAT=3,
         CHAR20=4,
         CHAR64=5,
+        INT8=6,
     };
 
     struct Param {
@@ -60,10 +61,12 @@ public:
         uint8_t min_len;
         void set_float(float v) const;
         void set_uint8(uint8_t v) const;
+        void set_int8(int8_t v) const;
         void set_uint32(uint32_t v) const;
         void set_char20(const char *v) const;
         void set_char64(const char *v) const;
         uint8_t get_uint8() const;
+        int8_t get_int8() const;
         uint32_t get_uint32() const;
         float get_float() const;
         const char *get_char20() const;
@@ -83,6 +86,7 @@ public:
     bool have_basic_id_2_info(void) const;
 
     bool set_by_name_uint8(const char *name, uint8_t v);
+    bool set_by_name_int8(const char *name, int8_t v);
     bool set_by_name_char64(const char *name, const char *s);
     bool set_by_name_string(const char *name, const char *s);
 


### PR DESCRIPTION
In [PR91](https://github.com/ArduPilot/ArduRemoteID/pull/91/files), the lock_level -1 was introduced. However, the parameter did not allow to set it to negative values, because it was defined as uint8_t.

This PR converts the lock_level to int8_t. 

Via DroneCAN GUI tool I can set it to -1. Via Mission Planner, it doesn't work. Not sure if something is missing in this PR or if it is a limitation of Mission Planner/MAVLink.