### PR TITLE
Option to not use or save BasicID info to parameters

### DIFF
--- a/RemoteIDModule/RemoteIDModule.ino
+++ b/RemoteIDModule/RemoteIDModule.ino
@@ -192,7 +192,7 @@ static void set_data(Transport &t)
       don't persist the BasicID2 if provided via mavlink to allow
       users to change BasicID2 on different days
      */
-    if (!g.have_basic_id_info() && !OPTIONS_DONT_SAVE_BASIC_ID_TO_PARAMETERS) {
+    if (!g.have_basic_id_info() && !(g.options & OPTIONS_DONT_SAVE_BASIC_ID_TO_PARAMETERS)) {
         if (basic_id.ua_type != 0 &&
             basic_id.id_type != 0 &&
             strnlen((const char *)basic_id.uas_id, 20) > 0) {
@@ -205,7 +205,7 @@ static void set_data(Transport &t)
     }
 
     // BasicID
-    if (g.have_basic_id_info()) {
+    if (g.have_basic_id_info() && !(g.options & OPTIONS_DONT_SAVE_BASIC_ID_TO_PARAMETERS)) {
         // from parameters
         UAS_data.BasicID[0].UAType = (ODID_uatype_t)g.ua_type;
         UAS_data.BasicID[0].IDType = (ODID_idtype_t)g.id_type;
@@ -219,7 +219,7 @@ static void set_data(Transport &t)
             UAS_data.BasicID[1].IDType = (ODID_idtype_t)g.id_type_2;
             ODID_COPY_STR(UAS_data.BasicID[1].UASID, g.uas_id_2);
             UAS_data.BasicIDValid[1] = 1;
-        } else if (strcmp((const char*)g.uas_id, (const char*)basic_id.uas_id) != 0 && !OPTIONS_DONT_SAVE_BASIC_ID_TO_PARAMETERS) {
+        } else if (strcmp((const char*)g.uas_id, (const char*)basic_id.uas_id) != 0 && !(g.options & OPTIONS_DONT_SAVE_BASIC_ID_TO_PARAMETERS)) {
             /*
               no BasicID 2 in the parameters, if one is provided on MAVLink
               and it is a different uas_id from the basicID1 then use it as BasicID2
@@ -235,7 +235,7 @@ static void set_data(Transport &t)
         }
     }
 
-    if (OPTIONS_DONT_SAVE_BASIC_ID_TO_PARAMETERS) {
+    if (g.options & OPTIONS_DONT_SAVE_BASIC_ID_TO_PARAMETERS) {
         if (basic_id.ua_type != 0 &&
         basic_id.id_type != 0 &&
         strnlen((const char *)basic_id.uas_id, 20) > 0) {

--- a/RemoteIDModule/RemoteIDModule.ino
+++ b/RemoteIDModule/RemoteIDModule.ino
@@ -219,7 +219,7 @@ static void set_data(Transport &t)
             UAS_data.BasicID[1].IDType = (ODID_idtype_t)g.id_type_2;
             ODID_COPY_STR(UAS_data.BasicID[1].UASID, g.uas_id_2);
             UAS_data.BasicIDValid[1] = 1;
-        } else if (strcmp((const char*)g.uas_id, (const char*)basic_id.uas_id) != 0 && !(g.options & OPTIONS_DONT_SAVE_BASIC_ID_TO_PARAMETERS)) {
+        } else if (strcmp((const char*)g.uas_id, (const char*)basic_id.uas_id) != 0) {
             /*
               no BasicID 2 in the parameters, if one is provided on MAVLink
               and it is a different uas_id from the basicID1 then use it as BasicID2

--- a/RemoteIDModule/RemoteIDModule.ino
+++ b/RemoteIDModule/RemoteIDModule.ino
@@ -192,7 +192,7 @@ static void set_data(Transport &t)
       don't persist the BasicID2 if provided via mavlink to allow
       users to change BasicID2 on different days
      */
-    if (!g.have_basic_id_info()) {
+    if (!g.have_basic_id_info() && !OPTIONS_DONT_SAVE_BASIC_ID_TO_PARAMETERS) {
         if (basic_id.ua_type != 0 &&
             basic_id.id_type != 0 &&
             strnlen((const char *)basic_id.uas_id, 20) > 0) {
@@ -219,7 +219,7 @@ static void set_data(Transport &t)
             UAS_data.BasicID[1].IDType = (ODID_idtype_t)g.id_type_2;
             ODID_COPY_STR(UAS_data.BasicID[1].UASID, g.uas_id_2);
             UAS_data.BasicIDValid[1] = 1;
-        } else if (strcmp((const char*)g.uas_id, (const char*)basic_id.uas_id) != 0) {
+        } else if (strcmp((const char*)g.uas_id, (const char*)basic_id.uas_id) != 0 && !OPTIONS_DONT_SAVE_BASIC_ID_TO_PARAMETERS) {
             /*
               no BasicID 2 in the parameters, if one is provided on MAVLink
               and it is a different uas_id from the basicID1 then use it as BasicID2
@@ -231,6 +231,24 @@ static void set_data(Transport &t)
                 UAS_data.BasicID[1].IDType = (ODID_idtype_t)basic_id.id_type;
                 ODID_COPY_STR(UAS_data.BasicID[1].UASID, basic_id.uas_id);
                 UAS_data.BasicIDValid[1] = 1;
+            }
+        }
+    }
+
+    if (OPTIONS_DONT_SAVE_BASIC_ID_TO_PARAMETERS) {
+        if (basic_id.ua_type != 0 &&
+        basic_id.id_type != 0 &&
+        strnlen((const char *)basic_id.uas_id, 20) > 0) {
+            if (strcmp((const char*)UAS_data.BasicID[0].UASID, (const char*)basic_id.uas_id) != 0 && strnlen((const char *)basic_id.uas_id, 20) > 0) {
+                UAS_data.BasicID[1].UAType = (ODID_uatype_t)basic_id.ua_type;
+                UAS_data.BasicID[1].IDType = (ODID_idtype_t)basic_id.id_type;
+                ODID_COPY_STR(UAS_data.BasicID[1].UASID, basic_id.uas_id);
+                UAS_data.BasicIDValid[1] = 1;
+            } else {
+                UAS_data.BasicID[0].UAType = (ODID_uatype_t)basic_id.ua_type;
+                UAS_data.BasicID[0].IDType = (ODID_idtype_t)basic_id.id_type;
+                ODID_COPY_STR(UAS_data.BasicID[0].UASID, basic_id.uas_id);
+                UAS_data.BasicIDValid[0] = 1;
             }
         }
     }

--- a/RemoteIDModule/parameters.h
+++ b/RemoteIDModule/parameters.h
@@ -108,5 +108,6 @@ private:
 
 // bits for OPTIONS parameter
 #define OPTIONS_FORCE_ARM_OK 1U<<0
+#define OPTIONS_DONT_SAVE_BASIC_ID_TO_PARAMETERS 1U<<1
 
 extern Parameters g;


### PR DESCRIPTION
In some scenario you don't want the ArduRemoteID device to store or use BasicID info from the parameters.

This PR adds the option OPTIONS_DONT_SAVE_BASIC_ID_TO_PARAMETERS to the options var. If set it won't use the basic ID info set  in the parameters nor will it save basicID info to parameters if nothing has been set.

