### PR TITLE
mavlink.cpp: fix errors that occur due to sending empty string

### DIFF
--- a/RemoteIDModule/mavlink.cpp
+++ b/RemoteIDModule/mavlink.cpp
@@ -294,8 +294,11 @@ void MAVLinkSerial::process_packet(mavlink_status_t &status, mavlink_message_t &
 
 void MAVLinkSerial::arm_status_send(void)
 {
+    static constexpr char reason_none[50] = "";
+
     const uint8_t status = parse_fail==nullptr?MAV_ODID_ARM_STATUS_GOOD_TO_ARM:MAV_ODID_ARM_STATUS_PRE_ARM_FAIL_GENERIC;
-    const char *reason = parse_fail==nullptr?"":parse_fail;
+    const char *reason = parse_fail==nullptr?reason_none:parse_fail;
+
     mavlink_msg_open_drone_id_arm_status_send(
         chan,
         status,


### PR DESCRIPTION
When arm status is good, an empty string is sent.

On the serial port i see the following error message:
![Screenshot from 2023-11-01 17-05-52](https://github.com/ArduPilot/ArduRemoteID/assets/35773661/e14895d4-822d-43ce-a250-b2eaa25adff9)

When i set anything else but an empty string, the error is gone.

I found a way to send an empty string and to get rid of the error, thats the solution proposed in this PR.