### PR TITLE
Reverted to older version of empy as the latest does not work for compiling

### DIFF
--- a/scripts/install_build_env.sh
+++ b/scripts/install_build_env.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-python3 -m pip install empy
+python3 -m pip install empy==3.3.4
 python3 -m pip install pymavlink
 python3 -m pip install dronecan
 python3 -m pip install pyserial


### PR DESCRIPTION
I could not compile the project with the latest version of empy. Setting the version to 3.3.4 allowed me to compile the project.