### PR TITLE
.github: move upload-artifact to @v4 to get CI to pass

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -37,7 +37,7 @@ jobs:
           allow_failure: true
 
       - name: Archive build
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
            name: binaries
            path: RemoteIDModule/ArduRemoteID*.bin

--- a/scripts/install_build_env.sh
+++ b/scripts/install_build_env.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-python3 -m pip install empy
+python3 -m pip install empy==3.3.4
 python3 -m pip install pymavlink
 python3 -m pip install dronecan
 python3 -m pip install pyserial


### PR DESCRIPTION
... now also clamps empy to a specific version so CI can pass.  Same version we use in ArduPilot.

